### PR TITLE
Record binder with custom id field.

### DIFF
--- a/rdf-test-suite/src/main/scala/ObjectExamples.scala
+++ b/rdf-test-suite/src/main/scala/ObjectExamples.scala
@@ -78,19 +78,20 @@ class ObjectExamples[Rdf <: RDF]()(implicit ops: RDFOps[Rdf], recordBinder: Reco
 
   }
 
-  case class City(cityName: String, otherNames: Set[String] = Set.empty)
+  case class City(uri: Rdf#Node, cityName: String, otherNames: Set[String] = Set.empty)
 
   object City {
 
     val clazz = URI("http://example.com/City#class")
     implicit val classUris = classUrisFor[City](clazz)
 
+    val uri = id
     val cityName = property[String](foaf("cityName"))
     val otherNames = set[String](foaf("otherNames"))
 
     implicit val binder: PGBinder[Rdf, City] =
-      pgbWithId[City](t => URI("http://example.com/" + t.cityName))
-        .apply(cityName, otherNames)(City.apply, City.unapply) withClasses classUris
+      pgbWithId[City](_.uri)
+        .apply(uri, cityName, otherNames)(City.apply, City.unapply) withClasses classUris
 
   }
 

--- a/rdf-test-suite/src/main/scala/RecordBinderTest.scala
+++ b/rdf-test-suite/src/main/scala/RecordBinderTest.scala
@@ -16,7 +16,7 @@ abstract class RecordBinderTest[Rdf <: RDF]()(implicit ops: RDFOps[Rdf], recordB
   val objects = new ObjectExamples
   import objects._
 
-  val city = City("Paris", Set("Panam", "Lutetia"))
+  val city = City(URI("http://example.com/Paris"), "Paris", Set("Panam", "Lutetia"))
   val verifiedAddress = VerifiedAddress("32 Vassar st", city)
   val person = Person("Alexandre Bertails")
   val personWithNickname = person.copy(nickname = Some("betehess"))

--- a/rdf/src/main/scala/Property.scala
+++ b/rdf/src/main/scala/Property.scala
@@ -4,16 +4,8 @@ import scala.util._
 
 trait Property[Rdf <: RDF, T] {
 
-  def uri: Rdf#URI
-
   def pos(t: T): Iterable[(Rdf#URI, PointedGraph[Rdf])]
 
   def extract(pointed: PointedGraph[Rdf]): Try[T]
-
-}
-
-object Property {
-
-  implicit def propertyToUri[Rdf <: RDF](p: Property[Rdf, _]): Rdf#URI = p.uri
 
 }

--- a/rdf/src/main/scala/binder/RecordBinder.scala
+++ b/rdf/src/main/scala/binder/RecordBinder.scala
@@ -48,6 +48,11 @@ class RecordBinder[Rdf <: RDF]()(implicit ops: RDFOps[Rdf]) {
     binder
   }
 
+  def id: Property[Rdf, Rdf#Node] = new Property[Rdf, Rdf#Node] {
+    def pos(ts: Rdf#Node): Iterable[(Rdf#URI, PointedGraph[Rdf])] = Set()
+    def extract(pointed: PointedGraph[Rdf]): Try[Rdf#Node] = Try(pointed.pointer)
+  }
+
   /**
    * declares a Property/Object element where T is in the object position
    */
@@ -89,8 +94,8 @@ class RecordBinder[Rdf <: RDF]()(implicit ops: RDFOps[Rdf]) {
   /**
    * Create PGB with pointer based on record fields.
    */
-  def pgbWithId[T](id: T => Rdf#URI) = new PGB[T] {
-    def makeSubject(t: T): Rdf#URI = id(t)
+  def pgbWithId[T](id: T => Rdf#Node) = new PGB[T] {
+    def makeSubject(t: T): Rdf#Node = id(t)
   }
 
   /**
@@ -107,7 +112,7 @@ class RecordBinder[Rdf <: RDF]()(implicit ops: RDFOps[Rdf]) {
 
   abstract class PGB[T] {
 
-    def makeSubject(t: T): Rdf#URI
+    def makeSubject(t: T): Rdf#Node
 
     def make(t: T, pos: Iterable[(Rdf#URI, PointedGraph[Rdf])]*)(implicit ops: RDFOps[Rdf]): PointedGraph[Rdf] = {
       val subject = makeSubject(t)


### PR DESCRIPTION
In the RDF world Resource URI is matter, but currently RecordBinder do not take this into account.

In my use case I need to have PointedGraph pointer to be available as case class field. And also sometimes I want create new resource with some URI and serialize it to PointedGraph. 

This pull request should be considered only as example of what I am trying to do. I've implemented it in a very dirty manner and it would be great if someone can help me to make it in a more idiomatic way. Any ideas are welcome and thanks in advance.
