### PR TITLE
Plantain Graph find method is not filtering objects.

### DIFF
--- a/plantain/src/main/scala/plantain/model/model.scala
+++ b/plantain/src/main/scala/plantain/model/model.scala
@@ -124,7 +124,7 @@ case class Graph(spo: Map[Node, Map[URI, Vector[Node]]], size: Int) extends Sesa
           }
           o <- objectt match {
             case ANY => os
-            case PlainNode(node) => if (os contains node) os else Iterable.empty
+            case PlainNode(node) => os filter { _ == node }
           }
         } yield Triple(s, p, o)
       }

--- a/rdf-test-suite/src/main/scala/DieselGraphExplorationTest.scala
+++ b/rdf-test-suite/src/main/scala/DieselGraphExplorationTest.scala
@@ -41,6 +41,18 @@ abstract class DieselGraphExplorationTest[Rdf <: RDF]()(implicit ops: RDFOps[Rdf
 
   }
 
+  "'/-' method must traverse the graph backward without duplicates" in {
+    val g = (
+      URI("http://example.org/1")
+      -- foaf.knows ->- URI("http://example.org/2")
+      -- foaf.knows ->- URI("http://example.org/3")
+    )
+
+    val known = PointedGraph[Rdf](URI("http://example.org/2"), g.graph) /- foaf.knows
+
+    known.map(_.pointer).toList must (have size 1 and contain (URI("http://example.org/1")))
+  }
+
   "we must be able to project nodes to Scala types" in {
 
     (betehess / foaf.age).as[Int] must be(Success(29))


### PR DESCRIPTION
This bug results in PlantainOps getSubjects method and diesel /- method to generate duplicate nodes. I have included a diesel test which fails for plantain implementation without the fix.
