### PR TITLE
Jena expects null to be a wildcard as well as ANY in matchTriples

### DIFF
--- a/jena/src/main/scala/jena/ImmutableJenaGraph.scala
+++ b/jena/src/main/scala/jena/ImmutableJenaGraph.scala
@@ -64,7 +64,7 @@ case class ImmutableJenaGraph(triples: Set[Jena#Triple], prefixes: Map[String, S
 
   def matchTriples(s: JenaNode, p: JenaNode, o: JenaNode): Iterator[Jena#Triple] = {
     triples.iterator.filter { case JenaOperations.Triple(_s, _p, _o) =>
-      (s == ANY || s == _s) && (p == ANY || p == _p)  && (o == ANY || o == _o)
+      (s == null || s == ANY || s == _s) && (p == null || p == ANY || p == _p)  && (o == null || o == ANY || o == _o)
     }
   }
 


### PR DESCRIPTION
This comes up for example when trying to serialize an ImmutableJenaGraph as N-TRIPLES or non-prettified Turtle.
