### PR TITLE
Remove duplicate licenses in project/build.scala,

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -36,17 +36,6 @@ object BuildSettings {
     pomIncludeRepository := { _ => false },
     pomExtra := (
       <url>https://github.com/w3c/banana-rdf</url>
-      <licenses>
-        <license>
-          <name>W3C License</name>
-          <url>http://opensource.org/licenses/W3C</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-      <scm>
-        <url>git@github.com:w3c/banana-rdf.git</url>
-        <connection>scm:git:git@github.com:w3c/banana-rdf.git</connection>
-      </scm>
       <developers>
         <developer>
           <id>betehess</id>
@@ -59,6 +48,10 @@ object BuildSettings {
           <url>http://bblfish.net/</url>
         </developer>
       </developers>
+      <scm>
+        <url>git@github.com:w3c/banana-rdf.git</url>
+        <connection>scm:git:git@github.com:w3c/banana-rdf.git</connection>
+      </scm>
     ),
     // bintray
     repository in bintray := "banana-rdf",


### PR DESCRIPTION
that results in a unusable POM (by Maven) generated and deployed in
http://dl.bintray.com/betehess/banana-rdf/org/w3/banana-rdf_2.10/0.5/#banana-rdf_2.10-0.5.pom
cf warning in:
http://www.scala-sbt.org/release/docs/Community/Using-Sonatype.html#third-pom-metadata
