### PR TITLE
allow publications to other than bintray

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -11,9 +11,9 @@ object BuildSettings {
 
   val logger = ConsoleLogger()
 
-  val buildSettings = Defaults.defaultSettings ++ defaultScalariformSettings ++ bintrayPublishSettings ++ Seq (
+  val buildSettings = Defaults.defaultSettings ++ publicationSettings ++ defaultScalariformSettings  ++ Seq (
     organization := "org.w3",
-    version      := "0.6-SNAPSHOT",
+    version      := "0.7-SNAPSHOT",
     scalaVersion := "2.11.2",
     crossScalaVersions := Seq("2.11.2", "2.10.4"),
     javacOptions ++= Seq("-source","1.7", "-target","1.7"),
@@ -27,14 +27,6 @@ object BuildSettings {
     resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/",
     resolvers += "Sonatype OSS Releases" at "http://oss.sonatype.org/content/repositories/releases/",
     resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
-    publishArtifact in Test := false,
-//    publishTo := {
-//      val nexus = "https://oss.sonatype.org/"
-//      if (version.value.trim.endsWith("SNAPSHOT"))
-//        Some("snapshots" at nexus + "content/repositories/snapshots")
-//      else
-//        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-//    },
     description := "RDF framework for Scala",
     startYear := Some(2012),
     pomIncludeRepository := { _ => false },
@@ -63,11 +55,34 @@ object BuildSettings {
         <connection>scm:git:git@github.com:w3c/banana-rdf.git</connection>
       </scm>
     ),
-    // bintray
-    repository in bintray := "banana-rdf",
-    bintrayOrganization in bintray := None,
     licenses += ("W3C", url("http://opensource.org/licenses/W3C"))
   )
+
+  //sbt -Dbanana.publish=bblfish.net:/home/hjs/htdocs/work/repo/
+  //sbt -Dbanana.publish=bintray
+  def publicationSettings =
+    (Option(System.getProperty("banana.publish")) match {
+      case Some("bintray") => Seq(
+        // bintray
+        repository in bintray := "banana-rdf",
+        bintrayOrganization in bintray := None
+      ) ++ bintrayPublishSettings
+      case opt: Option[String] => {
+        Seq(
+          publishTo <<= version { (v: String) =>
+            val nexus = "https://oss.sonatype.org/"
+            val other = opt.map(_.split(":"))
+            if (v.trim.endsWith("SNAPSHOT")) {
+              val repo = other.map(p => Resolver.ssh("banana.publish specified server", p(0), p(1) + "snapshots"))
+              repo.orElse(Some("snapshots" at nexus + "content/repositories/snapshots"))
+            } else {
+              val repo = other.map(p => Resolver.ssh("banana.publish specified server", p(0), p(1) + "resolver"))
+              repo.orElse(Some("releases" at nexus + "service/local/staging/deploy/maven2"))
+            }
+          }
+        )
+      }
+    }) ++ Seq( publishArtifact in Test := false)
 
   val jenaTestWIPFilter = Seq (
     testOptions in Test += Tests.Argument("-l", "org.w3.banana.jenaWIP")


### PR DESCRIPTION
There were two issues with the current pubication mechansim.
- Users without a bintray account kept getting a lot of error messages on starting sbt, as it could not find the bintray credentials file. The resulted in numerous lines such as `[warn] Credentials file /Users/hjs/.bintray/.credentials does not exist`
- Branches of banana-rdf should be allowed to pubish their code to repositories to try things out ( eg. I sometimes need to publish a library for rww-play before the main release is stabilised )

This patch allows those who wish to use bintray to do so, those who wish to use their own repo to do so too, and those who don't want to publish anything to not see the bintray error messages.

Also updated to 0.7-SNAPSHOT
