### PR TITLE
fixes that come about while integrating the new banana-rdf with rww-play

### DIFF
--- a/rdf-test-suite/rdf-test-suite_js/src/main/scala/UriSyntaxJasmineTest.scala
+++ b/rdf-test-suite/rdf-test-suite_js/src/main/scala/UriSyntaxJasmineTest.scala
@@ -44,6 +44,7 @@ abstract class UriSyntaxJasmineTest[Rdf <: RDF]()(implicit ops: RDFOps[Rdf])
 
     it("resolve should resolve the uri against the passed string") {
       expect(URI("http://example.com/foo").resolve(URI("bar")) == URI("http://example.com/bar")).toEqual(true)
+      expect(URI("http://example.com/foo").resolve(URI(".")) == URI("http://example.com/")).toEqual(true)
       expect(URI("http://example.com/foo/").resolve(URI("bar")) == URI("http://example.com/foo/bar")).toEqual(true)
     }
 

--- a/rdf-test-suite/src/main/scala/UriSyntaxTest.scala
+++ b/rdf-test-suite/src/main/scala/UriSyntaxTest.scala
@@ -39,7 +39,9 @@ abstract class UriSyntaxTest[Rdf <: RDF]()(implicit ops: RDFOps[Rdf]) extends Wo
 
   "resolve should resolve the uri against the passed string" in {
     URI("http://example.com/foo").resolve(URI("bar")) should be(URI("http://example.com/bar"))
+    URI("http://example.com/foo").resolve(URI(".")) should be(URI("http://example.com/"))
     URI("http://example.com/foo/").resolve(URI("bar")) should be(URI("http://example.com/foo/bar"))
+    URI("http://example.com/foo/").resolve(URI(".")) should be(URI("http://example.com/foo/"))
   }
 
   "resolveAgainst should work like resolve, just the other way around" in {


### PR DESCRIPTION
Finding the "/" uri of a Uri is part of the URI standard. It can be achieved with `URI("http://example.com/foo").resolve(URI("."))`.
