### PR TITLE
#139 -- move source files according to the Java convention; add the ecli...

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -96,6 +96,7 @@ object BuildSettings {
 // @see http://www.scala-sbt.org/release/docs/Classpaths.html
 // @see https://stackoverflow.com/a/7456491/1009693
 // @see https://groups.google.com/d/msg/simple-build-tool/aJwjxFH8EkE/D78tudfEfPAJ
+
 object BananaRdfBuild extends Build {
 
   import BuildSettings._


### PR DESCRIPTION
I used "git mv" to relocate all *.scala files according to the java convention (directory / package)

The project compiles & tests cleanly with sbt.

To make it easier to work with eclipse on this project, I added the 'eclipse' sbt plugin.

The sbt/eclipse configuration requires more work: currently, executing 'eclipse' in sbt results in a situation where 3 sub-projects: plantain, rdf, rdf-test-suite have each 3 sub-sub projects: common, js, jvm but the sbt/eclipse generated metadata for the */common sub-sub projects overwrites the js & jvm variants on top of each other. 
- Nicolas.
