### PR TITLE
Deleted one redundant check of URI and added one typematching for sesame

### DIFF
--- a/sesame/src/main/scala/org/w3/banana/sesame/SesameOps.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/SesameOps.scala
@@ -27,17 +27,13 @@ class SesameOps extends RDFOps[Sesame] with DefaultURIOps[Sesame] {
 
   // triple
 
-  def makeTriple(s: Sesame#Node, p: Sesame#URI, o: Sesame#Node): Sesame#Triple = new StatementImpl(s.asInstanceOf[Resource], p, o)
+  def makeTriple(s: Sesame#Node, p: Sesame#URI, o: Sesame#Node): Sesame#Triple =
+    s match {
+      case res:Resource=>  new StatementImpl(res, p, o)
+      case _=> throw new RuntimeException("makeTriple: in Sesame subject " + p.toString + " must be a either URI or BlankNode")
+    }
 
-  def fromTriple(t: Sesame#Triple): (Sesame#Node, Sesame#URI, Sesame#Node) = {
-    val s = t.getSubject
-    val p = t.getPredicate
-    val o = t.getObject
-    if (p.isInstanceOf[Sesame#URI])
-      (s, p.asInstanceOf[Sesame#URI], o)
-    else
-      throw new RuntimeException("fromTriple: predicate " + p.toString + " must be a URI")
-  }
+  def fromTriple(t: Sesame#Triple): (Sesame#Node, Sesame#URI, Sesame#Node) =  (t.getSubject, t.getPredicate, t.getObject)
 
   // node
 


### PR DESCRIPTION
I found that there is not need to check that property is URI as it is already passed as URI. But in the same time I think it is nice to remind users that with Sesame they can only pass Resource to subject instead of just isInstanceOf[Resource] error
