### PR TITLE
release/0.7

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -132,8 +132,8 @@ object BananaRdfBuild extends Build {
       aggregate in Test in rdf_jvm := false,
       aggregate in Test in rdfTestSuite_jvm := false
     )
-  ).dependsOn(rdf_jvm, rdfTestSuite_jvm, jena, sesame, ntriples, plantain_jvm, examples)
-   .aggregate(rdf_jvm, rdfTestSuite_jvm, jena, sesame, ntriples, plantain_jvm, examples)
+  ).dependsOn(rdf_jvm, rdfTestSuite_jvm, jena, sesame, ntriples_jvm, plantain_jvm, examples)
+   .aggregate(rdf_jvm, rdfTestSuite_jvm, jena, sesame, ntriples_jvm, plantain_jvm, examples)
 
   /** A virtual module for gathering experimental ones. */
   lazy val experimental = Project(


### PR DESCRIPTION
Without the ntriples package published, the sesame or the jena packages don't work, as they now have a dependency on ntriples. 

I wonder if this is a reason for #183 "publish banana" taking so long to reach the main maven repositories.

Also I wonder if this is not a reason to have a test suite that just runs the example packages after the others have been published, just to see if they can be run. Ie that would be a way of fullfilling #170 "examples project needs to be turned into test suites" in a useful way. 1. publish the main repo. Then run the example project in a way as to have it depend purely on the published jars.
