### PR TITLE
"application/json-ld;"->"application/ld+json"

### DIFF
--- a/rdf/common/src/main/scala/org/w3/banana/io/MimeType.scala
+++ b/rdf/common/src/main/scala/org/w3/banana/io/MimeType.scala
@@ -37,9 +37,12 @@ object MimeType {
 case class MimeType(mainType: String, subType: String, params: Map[String, String] = Map()) {
 
   lazy val mime: String = {
-    val paramString =
-      params.map { case (k, v) => s"""$k="$v"""" }.mkString("", ";", "")
-    s"${mainType}/${subType};${paramString}"
+    val paramString = {
+      val ps = params.map { case (k, v) => s"""$k="$v""""}.mkString("", ";", "")
+      if (ps.isEmpty) ""
+      else ";"+ps
+    }
+    s"${mainType}/${subType}${paramString}"
   }
 
 }

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameSyntax.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameSyntax.scala
@@ -62,7 +62,7 @@ object SesameSyntax {
 
   implicit val jsonLdFlattened: SesameSyntax[JsonLdFlattened] = jsonldSyntax(JSONLDMode.FLATTEN)
 
-  private def jsonldSyntax[T](mode: JSONLDMode) = new SesameSyntax[T] {
+  def jsonldSyntax[T](mode: JSONLDMode) = new SesameSyntax[T] {
     import org.w3.banana.sesame.Sesame.ops._
 
     def rdfWriter(os: OutputStream, base: String) = {


### PR DESCRIPTION
also `jsonldSyntax[T]` is private in Sesame but not in Jena. 
