### PR TITLE
enable Updates on Graphs, improve sig of Update

### DIFF
--- a/jena/src/main/scala/org/w3/banana/jena/JenaDatasetStore.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaDatasetStore.scala
@@ -65,8 +65,10 @@ class JenaDatasetStore(defensiveCopy: Boolean)(implicit ops: RDFOps[Jena], jenaU
   }
 
   def executeUpdate(dataset: Dataset, query: Jena#UpdateQuery, bindings: Map[String, Jena#Node]) = Try {
-    if (bindings.isEmpty)
+    if (bindings.isEmpty) {
       UpdateAction.execute(query, dataset)
+      dataset
+    }
     else
       throw new NotImplementedError("todo: how does one (can one?) set the bindings in a dataset in Jena?")
   }

--- a/jena/src/main/scala/org/w3/banana/jena/JenaModule.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaModule.scala
@@ -37,7 +37,8 @@ with XmlQueryResultsReaderModule {
 
   implicit val sparqlOps: SparqlOps[Jena] = new JenaSparqlOps
 
-  implicit val sparqlGraph: SparqlEngine[Jena, Try, Jena#Graph] = JenaGraphSparqlEngine(ops)
+  implicit val sparqlGraph: SparqlEngine[Jena, Try, Jena#Graph]
+    with SparqlUpdate[Rdf,Try, Rdf#Graph] = JenaGraphSparqlEngine(ops)
 
   import java.net.URL
   implicit val sparqlHttp: SparqlEngine[Jena, Future, URL] = new JenaSparqlHttpEngine

--- a/jena/src/main/scala/org/w3/banana/jena/JenaSparqlHttpEngine.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaSparqlHttpEngine.scala
@@ -36,12 +36,13 @@ class JenaSparqlHttpEngine(implicit ops: RDFOps[Jena], ec: ExecutionContext)
       qexec(endpoint, query, bindings).execSelect()
     }
 
-  def executeUpdate(endpoint: URL, query: Jena#UpdateQuery, bindings: Map[String, Jena#Node]): Future[Unit] =
+  def executeUpdate(endpoint: URL, query: Jena#UpdateQuery, bindings: Map[String, Jena#Node]): Future[URL] =
     Future {
       val ue = UpdateExecutionFactory.createRemote(query, endpoint.toString)
       // not sure how to set the bindings on ue
       //      if (bindings.nonEmpty)
       //        ue.
       ue.execute()
+      endpoint
     }
 }

--- a/rdf/common/src/main/scala/org/w3/banana/RDFModule.scala
+++ b/rdf/common/src/main/scala/org/w3/banana/RDFModule.scala
@@ -32,6 +32,7 @@ trait SparqlOpsModule extends RDFModule {
 trait SparqlGraphModule extends RDFModule {
 
   implicit val sparqlGraph: SparqlEngine[Rdf, Try, Rdf#Graph]
+    with SparqlUpdate[Rdf,Try, Rdf#Graph]
 
 }
 

--- a/rdf/common/src/main/scala/org/w3/banana/SparqlUpdate.scala
+++ b/rdf/common/src/main/scala/org/w3/banana/SparqlUpdate.scala
@@ -2,7 +2,14 @@ package org.w3.banana
 
 trait SparqlUpdate[Rdf <: RDF, M[_], A] {
 
-  def executeUpdate(a: A, query: Rdf#UpdateQuery, bindings: Map[String, Rdf#Node]): M[Unit]
+  /**
+   * run a Sparql Update query against a given object A.
+   * @param a
+   * @param query
+   * @param bindings
+   * @return the changed A
+   */
+  def executeUpdate(a: A, query: Rdf#UpdateQuery, bindings: Map[String, Rdf#Node]): M[A]
 
   val sparqlUpdateSyntax = new syntax.SparqlUpdateSyntax[Rdf, M, A]
 

--- a/sesame/src/main/scala/org/w3/banana/sesame/SesameModule.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/SesameModule.scala
@@ -36,7 +36,8 @@ trait SesameModule
 
   implicit val sparqlOps: SparqlOps[Sesame] = SesameSparqlOps
 
-  implicit val sparqlGraph: SparqlEngine[Sesame, Try, Sesame#Graph] = SesameGraphSparqlEngine()
+  implicit val sparqlGraph: SparqlEngine[Sesame, Try, Sesame#Graph]
+    with SparqlUpdate[Rdf,Try, Rdf#Graph] = SesameGraphSparqlEngine()
 
   implicit val rdfStore: RDFStore[Sesame, Try, RepositoryConnection] with SparqlUpdate[Sesame, Try, RepositoryConnection] = new SesameStore
 

--- a/sesame/src/main/scala/org/w3/banana/sesame/SesameStore.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/SesameStore.scala
@@ -54,10 +54,11 @@ class SesameStore
     result
   }
 
-  def executeUpdate(conn: RepositoryConnection, query: Sesame#UpdateQuery, bindings: Map[String, Sesame#Node]): Try[Unit] = Try {
+  def executeUpdate(conn: RepositoryConnection, query: Sesame#UpdateQuery, bindings: Map[String, Sesame#Node]): Try[RepositoryConnection] = Try {
     val updateQuery = conn.prepareUpdate(QueryLanguage.SPARQL, query.query)
     bindings foreach { case (name, value) => updateQuery.setBinding(name, value) }
     updateQuery.execute()
+    conn
   }
 
   /* GraphStore */


### PR DESCRIPTION
SPARQL Queries currently work on graphs. This allows Sparql Updates to work on graphs too.
In [rww-play](/read-write-web/rww-play) (dev branch) mostly updates on graphs are needed. DataStores are not used yet. Note that this used to work in various previous versions, and I depended on this functionality.
