### PR TITLE
fix NTriplesReader to work with ScalaJS

### DIFF
--- a/io/ntriples/common/src/main/scala/org/w3/banana/io/NTriplesReader.scala
+++ b/io/ntriples/common/src/main/scala/org/w3/banana/io/NTriplesReader.scala
@@ -86,6 +86,11 @@ object  NTriplesParser {
 
   def whitespace(ci: Int) = {
     val c = ci.toChar
+    c == ' ' || c == '\t'
+  }
+
+  def whitespaceEOL(ci: Int) = {
+    val c = ci.toChar
     c == ' ' || c == '\t' || c == '\n' || c == '\r'
   }
 
@@ -414,7 +419,7 @@ class NTriplesParser[Rdf <: RDF](reader: Reader,
   private def parseNextTriple(): Try[Rdf#Triple] = {
     read() match {
       case -1 => Failure(EOF("while starting to parse next triple"))
-      case w if whitespace(w) => parseNextTriple()
+      case w if whitespaceEOL(w) => parseNextTriple()
       case '#' => {
         parseComment()
         parseNextTriple()

--- a/plantain/jvm/src/test/scala/org/w3/banana/plantain/PlantainTest.scala
+++ b/plantain/jvm/src/test/scala/org/w3/banana/plantain/PlantainTest.scala
@@ -10,7 +10,7 @@ class PlantainTurtleTest extends TurtleTestSuite[Plantain, Try]
 
 class PlantainNTripleReaderTestSuite extends NTriplesReaderTestSuite[Plantain]
 
-class PlantainNTripleWriterTestSuite extends NTriplesReaderTestSuite[Plantain]
+class PlantainNTripleWriterTestSuite extends NTriplesWriterTestSuite[Plantain]
 
 class PlantainSimpleClassifyTest() extends SimpleClassifyTest[Plantain](
   new SimpleMappingGenerator[Plantain](_))


### PR DESCRIPTION
- Removed LineNumberReader
- removed reliance on Char.isWhiteSpace
