### PR TITLE
Banana/meta

### DIFF
--- a/jena/src/test/scala/org/w3/banana/jena/JenaAnnotationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaAnnotationTest.scala
@@ -1,0 +1,9 @@
+package org.w3.banana.jena
+
+import org.w3.banana.meta._
+import org.w3.banana.annotations._
+
+class JenaAnnotationTest extends AnnotationTest[Jena]
+{
+  override def materialize(p: Person): Map[Jena#URI, Any] = Mappable.materializeMappable[Person].toMap[Jena](p)
+}

--- a/meta/shared/shared-sources.iml
+++ b/meta/shared/shared-sources.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="shared-sources" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../.." external.system.id="SBT" type="SHARED_SOURCES_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/scala" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="SBT: com.softwaremill.macwire:macros_2.11:0.7.3:jar" level="project" />
+    <orderEntry type="library" name="SBT: org.scala-lang:scala-library:2.11.5:jar" level="project" />
+    <orderEntry type="library" name="SBT: org.scala-lang:scala-reflect:2.11.2:jar" level="project" />
+    <orderEntry type="library" name="SBT: org.scala-lang.modules:scala-parser-combinators_2.11:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="SBT: org.scala-lang.modules:scala-xml_2.11:1.0.1:jar" level="project" />
+  </component>
+</module>

--- a/meta/shared/src/main/scala/org/w3/banana/annotations/Mappable.scala
+++ b/meta/shared/src/main/scala/org/w3/banana/annotations/Mappable.scala
@@ -1,0 +1,89 @@
+package org.w3.banana.annotations
+
+import scala.collection.immutable.Map
+import scala.language.experimental.macros
+import scala.reflect.macros._
+import org.w3.banana.{RDF,RDFOps}
+
+/**
+ * base prefix
+ * @param base default prefix
+ */
+class vocab(base:String) extends scala.annotation.ClassfileAnnotation
+
+/**
+ * URI for each property
+ * @param name if no name is provided, takes term name
+ */
+class prop(name:String ="") extends scala.annotation.ClassfileAnnotation
+
+trait Mappable[T] {
+  def toMap[Rdf<:RDF](t: T)(implicit ops:RDFOps[Rdf]): Map[Rdf#URI, Any]
+}
+
+/**
+ * This object contains macros that extracts properties from annotations and makes maps
+ */
+object Mappable {
+
+  implicit def materializeMappable[T]: Mappable[T] = macro materializeMappableImpl[T]
+
+
+  /**
+   * Creates a map of rdf properties
+   * @param c macro context
+   * @tparam T type
+   * @return Map[Rdf#URI,Any]
+   */
+  def materializeMappableImpl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[Mappable[T]] = {
+    import c.universe._
+    /**
+     * Extracting value of first param of annotation
+     * @param anno
+     * @return
+     */
+    def extract(anno:Annotation):String =  {
+      val ch = anno.tree.children
+      if(ch.size>1){
+        val args = ch.tail.head.children
+        c.eval(c.Expr[String](args.tail.head))
+      }  else ""
+    }
+
+    def join(voc:String,url:String) = voc.last match {
+      case '#' | '/'=> voc + url
+      case other => voc+'/'+url
+    }
+
+    val tpe =c.weakTypeOf[T]
+    val pte= c.weakTypeOf[prop]
+    val vte = c.weakTypeOf[vocab]
+    val vocs = for{
+      v <- tpe.typeSymbol.asClass.annotations
+      if v.tree.tpe =:= vte
+    } yield extract(v)
+
+
+    val toMapParams = for{
+      m<-tpe.members
+      if m.isTerm
+      term = m.asTerm
+      if term.isVal || term.isVar || term.isAccessor || term.isCaseAccessor || term.isGetter
+      anno <- term.annotations
+      if anno.tree.tpe =:= pte
+      param = if(term.isVal || term.isVar) term.getter.asTerm else term.accessed.asTerm
+      value = param.name
+      url = extract(anno).replace(" ","_")
+      if url.contains(":") || vocs.size>0
+      name =  if(url.contains(":")) url else if(url.size>0) join(vocs.head,url) else join(vocs.head,term.name.decodedName.toString.trim)
+    } yield {
+      q"ops.makeUri($name) -> t.$value"
+    }
+
+    c.Expr[Mappable[T]] { q"""
+      new Mappable[$tpe] {
+        def toMap[Rdf<:org.w3.banana.RDF](t: $tpe)(implicit ops:org.w3.banana.RDFOps[Rdf]): Map[Rdf#URI, Any] = Map(..$toMapParams)
+      }
+    """ }
+  }
+}

--- a/meta/shared/src/src-sources.iml
+++ b/meta/shared/src/src-sources.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="src-sources" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/../../.." external.system.id="SBT" type="SHARED_SOURCES_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="SBT: org.scala-lang:scala-library:2.11.5:jar" level="project" />
+    <orderEntry type="library" name="SBT: org.scala-lang.modules:scala-parser-combinators_2.11:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="SBT: org.scala-lang.modules:scala-xml_2.11:1.0.1:jar" level="project" />
+  </component>
+</module>

--- a/plantain/jvm/src/test/scala/org/w3/banana/plantain/PlantainTest.scala
+++ b/plantain/jvm/src/test/scala/org/w3/banana/plantain/PlantainTest.scala
@@ -5,6 +5,9 @@ import org.w3.banana.io.{NTriplesReaderTestSuite, TurtleTestSuite}
 import org.w3.banana.isomorphism._
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
+import org.w3.banana.meta._
+import org.w3.banana.annotations._
+
 
 class PlantainTurtleTest extends TurtleTestSuite[Plantain, Try]
 
@@ -45,3 +48,7 @@ class PlantainIsoTest() extends IsomorphismTests[Plantain]
 // New shared tests
 
 class PlantainGraphUnionJvmTest extends GraphUnionJvmTest[Plantain]
+
+class PlantainAnnotationTest extends AnnotationTest[Plantain]{
+  override def materialize(p: Person): Map[Plantain#URI, Any] = Mappable.materializeMappable[Person].toMap[Plantain](p)
+}

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/meta/AnnotationTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/meta/AnnotationTest.scala
@@ -1,0 +1,35 @@
+package org.w3.banana.meta
+
+import org.scalatest.{Matchers, WordSpec}
+import org.w3.banana.{RDFOps, RDF}
+import org.w3.banana.annotations.{Mappable, prop, vocab}
+import scala.language.experimental.macros
+
+/**
+ * Tests how properties are extracted from class by RDF annotations
+ * @param ops implicit RDF operations
+ * @tparam Rdf RDF typeclass
+ */
+abstract class AnnotationTest[Rdf <: RDF](implicit ops:RDFOps[Rdf]) extends WordSpec with Matchers {
+
+
+  def materialize(p:Person):Map[Rdf#URI,Any] //macroses are evaluated when they are called that is why I put them to final classes
+
+  "extract RDF properties from classes" in {
+
+    val p = new Person("Foo","Bar")
+    val m = materialize(p)
+    //not all rdf storess compare URIs in a right way (by string value) some compare by reference,
+    // that is why I convert to string
+    val keys = m.keys.map(_.toString)
+    keys should contain (ops.makeUri("http://example.org/name").toString)
+    keys should contain (ops.makeUri("http://example.org/surname").toString)
+    keys should contain (ops.makeUri("http://example.org/mutant").toString)
+    keys should contain (ops.makeUri("http://scala-lang.org/immutable").toString)
+
+
+  }
+
+}
+
+

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/meta/Person.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/meta/Person.scala
@@ -1,0 +1,19 @@
+package org.w3.banana.meta
+
+import org.scalatest.{Matchers, WordSpec}
+import org.w3.banana.{RDFOps, RDF}
+import org.w3.banana.annotations.{Mappable, prop, vocab}
+import scala.language.experimental.macros
+
+@vocab(base = "http://example.org")
+class Person(first:String,second:String) //annotation of constructor params not yet works
+{
+
+  @prop val name:String = first //if no name is provided then vocab + property name is used
+  @prop val surname:String = second
+
+  @prop(name = "mutant") var war = "mutable value"
+
+  @prop(name = "http://scala-lang.org/immutable") val vi = "immutable value"
+
+}

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
@@ -2,10 +2,11 @@ package org.w3.banana.sesame.io
 
 import java.io._
 
+import org.openrdf.rio
 import org.w3.banana.RDFWriterSelector
 import org.w3.banana.io._
 import org.w3.banana.sesame.{Sesame, SesameOps}
-
+import scala.collection.JavaConversions._
 import scala.util._
 
 class SesameRDFWriter[T: Syntax](implicit
@@ -13,19 +14,35 @@ class SesameRDFWriter[T: Syntax](implicit
   sesameSyntax: SesameSyntax[T]
 ) extends RDFWriter[Sesame, Try, T] {
 
-  def write(graph: Sesame#Graph, os: OutputStream, base: String): Try[Unit] = Try {
-    val sWriter = sesameSyntax.rdfWriter(os, base)
+  /**
+   * Sort function that sorts triplets in order to produce nice looking Turtle
+   * @param a first triplet
+   * @param b second triplet
+   * @return false if order change is required
+   */
+  protected def sortTriple(a:Sesame#Triple,b:Sesame#Triple) = if(a.getSubject==b.getSubject)
+    a.getPredicate.stringValue < b.getPredicate.stringValue else a.getSubject.stringValue < b.getSubject.stringValue
+
+  /**
+   * Writes Sesame graph with turtle writer
+   * @param graph
+   * @param sWriter
+   */
+  protected def writeGraph(graph:Sesame#Graph,sWriter:rio.RDFWriter) = {
     sWriter.startRDF()
-    ops.getTriples(graph) foreach sWriter.handleStatement
+    for(n <- graph.getNamespaces) sWriter.handleNamespace(n.getPrefix,n.getName)
+    val trips = ops.getTriples(graph).toStream.sortWith(sortTriple)
+    trips foreach sWriter.handleStatement
     sWriter.endRDF()
   }
+
+  def write(graph: Sesame#Graph, os: OutputStream, base: String): Try[Unit] =
+    Try (    writeGraph(graph, sesameSyntax.rdfWriter(os, base)) )
 
   def asString(graph: Sesame#Graph, base: String): Try[String] = Try {
     val result = new StringWriter()
     val sWriter = sesameSyntax.rdfWriter(result, base)
-    sWriter.startRDF()
-    ops.getTriples(graph) foreach sWriter.handleStatement
-    sWriter.endRDF()
+    this.writeGraph(graph,sWriter)
     result.toString
   }
 }

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
@@ -20,7 +20,7 @@ class SesameRDFWriter[T: Syntax](implicit
    * @param b second triplet
    * @return false if order change is required
    */
-  protected def sortTriple(a:Sesame#Triple,b:Sesame#Triple) = if(a.getSubject==b.getSubject)
+  protected def sortTriple(a:Sesame#Triple,b:Sesame#Triple) = if(a.getSubject.stringValue==b.getSubject.stringValue)
     a.getPredicate.stringValue < b.getPredicate.stringValue else a.getSubject.stringValue < b.getSubject.stringValue
 
   /**

--- a/sesame/src/test/scala/org/w3/banana/sesame/SesameAnnotationTest.scala
+++ b/sesame/src/test/scala/org/w3/banana/sesame/SesameAnnotationTest.scala
@@ -1,0 +1,9 @@
+package org.w3.banana.sesame
+
+import org.w3.banana.meta._
+import org.w3.banana.annotations._
+
+
+class SesameAnnotationTest extends AnnotationTest[Sesame]{
+  override def materialize(p: Person): Map[Sesame#URI, Any] = Mappable.materializeMappable[Person].toMap[Sesame](p)
+}


### PR DESCRIPTION
I added macros that extracts properties from classes
How it works, consider following case:

``` scala
@vocab(base = "http://example.org")
class Person(first:String,second:String) //annotation of constructor params not yet works
{
  @prop val name:String = first //if no name is provided then vocab + property name is used
  @prop val surname:String = second
  @prop(name = "mutant") var war = "mutable value"
  @prop(name = "http://scala-lang.org/immutable") val vi = "immutable value"
}
```

Here vocab annotation provides base prefix.
If we want to extract properties, for instance to sesame, we should call: 

``` scala
val p = new Person("Foo","Bar")
val map:Map[Sesame#URI,Any] = Mappable.materializeMappable[Person].toMap[Sesame](p)
```

As a result we will get:

``` scala
Map(http://example.org/immutable -> immutable value, http://example.org/mutant -> mutable value, http://example.org/surname  -> Bar, http://example.org/name  -> Foo)
```

In future implicit class will be provided, so it will look like: 

``` scala
val p = new Person("Foo","Bar")
val map:Map[Sesame#URI,Any]  = p.toMap[Sesame]
```
