### PR TITLE
Refactored the publication settings

### DIFF
--- a/project/GitHelper.scala
+++ b/project/GitHelper.scala
@@ -1,0 +1,25 @@
+import sbt._
+
+object GitHelper {
+
+  val HeadRefsPattern = """refs/heads/(.*)\s""".r
+
+  def symbolicRefProcess = Process("git symbolic-ref HEAD")
+
+  def abbrevRefProcess = Process("git rev-parse --abbrev-ref HEAD")
+
+  def headShaProcess = Process("git rev-parse --short HEAD")
+
+  def headSha(): String = headShaProcess.!!.stripLineEnd
+
+  def commitRangeCount(start: String, end: String): Int =
+    Process(s"git rev-list ${start}..${end}").lines.size
+
+  def revisionFromBranch(branch: String, commitish: String): Int = {
+    abbrevRefProcess.!!.stripLineEnd match {
+      case `branch` => 0
+      case _ =>
+        commitRangeCount(branch, commitish)
+    }
+  }
+}

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -56,6 +56,10 @@ object Publishing {
       }
     }
 
+    // regex matching at least 4 word character at the very end of the
+    // String (basically the SHA from the version if it exists)
+    val r = """\w{4,}$""".r
+
     Option(System.getProperty("banana.publish")) match {
 
       case Some("bintray") =>
@@ -67,7 +71,7 @@ object Publishing {
       case None =>
         val nexus = "https://oss.sonatype.org/"
         val publishSetting = publishTo <<= version { (v: String) =>
-          if (v.trim.endsWith("SNAPSHOT"))
+          if (r.findFirstMatchIn(v).isDefined)
             Some("snapshots" at nexus + "content/repositories/snapshots")
           else
             Some("releases" at nexus + "service/local/staging/deploy/maven2")
@@ -76,7 +80,7 @@ object Publishing {
 
       case Some(SshUri(hostname, basePath)) =>
         val publishSetting = publishTo <<= version { (v: String) =>
-          if (v.trim.endsWith("SNAPSHOT"))
+          if (r.findFirstMatchIn(v).isDefined)
             Some(Resolver.ssh("banana.publish specified server", hostname, basePath + "snapshots"))
           else
             Some(Resolver.ssh("banana.publish specified server", hostname, basePath + "resolver"))

--- a/project/build.scala
+++ b/project/build.scala
@@ -8,12 +8,12 @@ import sbtunidoc.Plugin._
 import ScalaJSPlugin.autoImport._
 
 object BuildSettings {
-  import Publishing._
+
   implicit val logger = ConsoleLogger()
 
-  val buildSettings = publicationSettings ++ defaultScalariformSettings ++ Seq(
+  val buildSettings = Publishing.publicationSettings ++ defaultScalariformSettings ++ Seq(
     organization := "org.w3",
-    version := "0.8.0-SNAPSHOT",
+    version := "0.8.0." + GitHelper.headSha(),
     scalaVersion := "2.11.5",
     crossScalaVersions := Seq("2.11.5", "2.10.4"),
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),

--- a/project/build.scala
+++ b/project/build.scala
@@ -50,7 +50,7 @@ object BananaRdfBuild extends Build {
     .settings(zcheckJvmSettings:_*)
 
   lazy val banana_js = bananaM
-    .project(Js, rdf_js, rdfTestSuite_js, plantain_js, n3Js, jsonldJs)
+    .project(Js, rdf_js, rdfTestSuite_js, ntriples_js, plantain_js, n3Js, jsonldJs)
     .settings(zcheckJsSettings:_*)
 
   /** `rdf`, a cross-compiled base module for RDF abstractions. */


### PR DESCRIPTION
I refactored the publication settings (now I can understand what happens :-)

Also uses the Git SHA instead of `-SNAPSHOT` for the version. This makes it a lot easier to publish things (pattern reused from my previous job :-)

Note that some kind of regression was recently introduced in sbt-bintray https://github.com/softprops/bintray-sbt/issues/47.
