### PR TITLE
[n3-js] Bumped to 0.4.2. Implemented RDF model for N3.js.

### DIFF
--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3.scala
@@ -171,6 +171,11 @@ trait Util extends js.Object {
   def isPrefixedName(s: String): Boolean = js.native
   def expandPrefixedName(s: String, prefixes: Dynamic): String = js.native
 
+  def createIRI(iri: String): String = js.native
+  def createLiteral(lexicalForm: String, langOrIri: String): String = js.native
+  def createLiteral(i: Int): String = js.native
+  def createLiteral(b: Boolean): String = js.native
+
 }
 
 trait Store extends js.Object {

--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3js.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3js.scala
@@ -1,8 +1,6 @@
 package org.w3.banana
 package n3js
 
-import scala.scalajs.js
-
 /** A N3.js-based implementation of the RDF model.
   * 
   * For now, only the URIs and Literal are natively handled by N3.js.

--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3js.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3js.scala
@@ -12,11 +12,11 @@ trait N3js extends RDF {
   type Triple = (Node, URI, Node)
   type Node = Any
   type URI = String
-  type BNode = model.BNode
+  type BNode = n3js.BNode
   type Literal = String
   type Lang = String
 
-  type MGraph = model.MGraph[Node, URI, Node]
+  type MGraph = n3js.MGraph[Node, URI, Node]
 
   // types for the graph traversal API
   type NodeMatch = Node

--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3js.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3js.scala
@@ -1,0 +1,29 @@
+package org.w3.banana
+package n3js
+
+import scala.scalajs.js
+
+/** A N3.js-based implementation of the RDF model.
+  * 
+  * For now, only the URIs and Literal are natively handled by N3.js.
+  */
+trait N3js extends RDF {
+
+  // types related to the RDF datamodel
+  type Graph = plantain.model.Graph[Node, URI, Node]
+  type Triple = (Node, URI, Node)
+  type Node = Any
+  type URI = String
+  type BNode = model.BNode
+  type Literal = String
+  type Lang = String
+
+  type MGraph = model.MGraph[Node, URI, Node]
+
+  // types for the graph traversal API
+  type NodeMatch = Node
+  type NodeAny = Null
+
+}
+
+object N3js extends N3jsModule

--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3jsMGraphOps.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3jsMGraphOps.scala
@@ -1,0 +1,33 @@
+package org.w3.banana
+package n3js
+
+import plantain.{ model => pm }
+
+trait N3jsMGraphOps extends MGraphOps[N3js] {
+
+  def makeMGraph(graph: N3js#Graph): N3js#MGraph = new model.MGraph(graph)
+
+  def makeEmptyMGraph(): N3js#MGraph = new model.MGraph(pm.Graph.empty)
+
+  def addTriple(mgraph: N3js#MGraph, triple: N3js#Triple): mgraph.type = {
+    val (s, p, o) = triple
+    mgraph.graph += (s, p, o)
+    mgraph
+  }
+
+  def removeTriple(mgraph: N3js#MGraph, triple: N3js#Triple): mgraph.type = {
+    val (s, p, o) = triple
+    mgraph.graph -= (s, p, o)
+    mgraph
+  }
+
+  def exists(mgraph: N3js#MGraph, triple: N3js#Triple): Boolean = {
+    val (s, p, o) = triple
+    mgraph.graph.find(Some(s), Some(p), Some(o)).nonEmpty
+  }
+
+  def sizeMGraph(mgraph: N3js#MGraph): Int = mgraph.graph.size
+
+  def makeIGraph(mgraph: N3js#MGraph): N3js#Graph = mgraph.graph
+
+}

--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3jsMGraphOps.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3jsMGraphOps.scala
@@ -1,13 +1,11 @@
 package org.w3.banana
 package n3js
 
-import plantain.{ model => pm }
-
 trait N3jsMGraphOps extends MGraphOps[N3js] {
 
-  def makeMGraph(graph: N3js#Graph): N3js#MGraph = new model.MGraph(graph)
+  def makeMGraph(graph: N3js#Graph): N3js#MGraph = new MGraph(graph)
 
-  def makeEmptyMGraph(): N3js#MGraph = new model.MGraph(pm.Graph.empty)
+  def makeEmptyMGraph(): N3js#MGraph = new MGraph(plantain.model.Graph.empty)
 
   def addTriple(mgraph: N3js#MGraph, triple: N3js#Triple): mgraph.type = {
     val (s, p, o) = triple

--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3jsModule.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3jsModule.scala
@@ -1,0 +1,21 @@
+package org.w3.banana
+package n3js
+
+import org.w3.banana.io._
+import scala.concurrent.Future
+import scalajs.concurrent.JSExecutionContext.Implicits.runNow
+
+trait N3jsModule
+extends RDFModule
+with RDFOpsModule
+with RecordBinderModule {
+
+  type Rdf = N3js
+
+  implicit val ops: RDFOps[N3js] = N3jsOps
+
+  implicit val recordBinder: binder.RecordBinder[N3js] = binder.RecordBinder[N3js]
+
+  implicit val turtleReader: RDFReader[Rdf, Future, Turtle] = new n3js.io.N3jsTurtleParser[N3js]
+
+}

--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3jsOps.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3jsOps.scala
@@ -34,7 +34,7 @@ object N3jsOps extends RDFOps[N3js] with N3jsMGraphOps with DefaultURIOps[N3js] 
     funBNode: N3js#BNode => T,
     funLiteral: N3js#Literal => T
   ): T = node match {
-    case bnode @ BNode(_)               => funBNode(bnode)
+    case bnode @ n3js.BNode(_)          => funBNode(bnode)
     case s: String if Util.isIRI(s)     => funURI(s)
     case s: String if Util.isLiteral(s) => funLiteral(s)
   }
@@ -47,9 +47,9 @@ object N3jsOps extends RDFOps[N3js] with N3jsMGraphOps with DefaultURIOps[N3js] 
 
   // bnode
 
-  final def makeBNode(): N3js#BNode = model.BNode(UUID.randomUUID().toString)
+  final def makeBNode(): N3js#BNode = n3js.BNode(UUID.randomUUID().toString)
 
-  final def makeBNodeLabel(label: String): N3js#BNode = model.BNode(label)
+  final def makeBNodeLabel(label: String): N3js#BNode = n3js.BNode(label)
 
   final def fromBNode(bnode: N3js#BNode): String = bnode.label
 

--- a/N3.js/src/main/scala/org/w3/banana/n3js/N3jsOps.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/N3jsOps.scala
@@ -1,0 +1,129 @@
+package org.w3.banana
+package n3js
+
+import java.util.UUID
+import org.w3.banana.isomorphism._
+
+object N3jsOps extends RDFOps[N3js] with N3jsMGraphOps with DefaultURIOps[N3js] {
+
+  import N3.Util
+
+  // graph
+
+  final val emptyGraph: N3js#Graph = plantain.model.Graph(Map.empty, 0)
+
+  final def makeGraph(triples: Iterable[N3js#Triple]): N3js#Graph =
+    triples.foldLeft(emptyGraph) { case (g, (s, p, o)) => g + (s, p, o) }
+
+  final def getTriples(graph: N3js#Graph): Iterable[N3js#Triple] = graph.triples
+
+  def graphSize(graph: N3js#Graph): Int = graph.size
+
+  // triple
+
+  final def makeTriple(s: N3js#Node, p: N3js#URI, o: N3js#Node): N3js#Triple =
+    (s, p, o)
+
+  final def fromTriple(t: N3js#Triple): (N3js#Node, N3js#URI, N3js#Node) = t
+
+  // node
+
+  final def foldNode[T](
+    node: N3js#Node)(
+    funURI: N3js#URI => T,
+    funBNode: N3js#BNode => T,
+    funLiteral: N3js#Literal => T
+  ): T = node match {
+    case bnode @ BNode(_)               => funBNode(bnode)
+    case s: String if Util.isIRI(s)     => funURI(s)
+    case s: String if Util.isLiteral(s) => funLiteral(s)
+  }
+
+  // URI
+
+  final def fromUri(uri: N3js#URI): String = uri
+
+  final def makeUri(s: String): N3js#URI = s
+
+  // bnode
+
+  final def makeBNode(): N3js#BNode = model.BNode(UUID.randomUUID().toString)
+
+  final def makeBNodeLabel(label: String): N3js#BNode = model.BNode(label)
+
+  final def fromBNode(bnode: N3js#BNode): String = bnode.label
+
+  // literal
+
+  final val __rdfLangString = makeUri("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")
+
+  final def makeLiteral(lexicalForm: String, datatype: N3js#URI): N3js#Literal =
+    Util.createLiteral(lexicalForm, datatype)
+
+  final def makeLangTaggedLiteral(lexicalForm: String, lang: N3js#Lang): N3js#Literal =
+    Util.createLiteral(lexicalForm, lang)
+
+  final def fromLiteral(literal: N3js#Literal): (String, N3js#URI, Option[N3js#Lang]) = {
+    val lang = Util.getLiteralLanguage(literal)
+    val langOpt = if (lang.isEmpty) None else Some(lang)
+    (Util.getLiteralValue(literal), Util.getLiteralType(literal), langOpt)
+  }
+
+  // lang
+
+  final def makeLang(langString: String): N3js#Lang = langString
+
+  final def fromLang(lang: N3js#Lang): String = lang
+
+  // graph traversal
+
+  final val ANY: N3js#NodeAny = null
+
+  implicit def toConcreteNodeMatch(node: N3js#Node): N3js#NodeMatch = node
+
+  final def foldNodeMatch[T](
+    nodeMatch: N3js#NodeMatch)(
+    funANY: => T,
+      funConcrete: N3js#Node => T
+  ): T = nodeMatch match {
+    case null => funANY
+    case node => funConcrete(node)
+  }
+
+  final def find(
+    graph: N3js#Graph,
+    subject: N3js#NodeMatch,
+    predicate: N3js#NodeMatch,
+    objectt: N3js#NodeMatch
+  ): Iterator[N3js#Triple] = predicate match {
+    case p: N3js#URI => graph.find(Option(subject), Some(p), Option(objectt)).iterator
+    case null            => graph.find(Option(subject), None, Option(objectt)).iterator
+    case p               => sys.error(s"[find] invalid value in predicate position: $p")
+  }
+
+  // graph union
+
+  final def union(graphs: Seq[N3js#Graph]): N3js#Graph = {
+    var mgraph = makeEmptyMGraph()
+    graphs.foreach(graph => addTriples(mgraph, graph.triples))
+    mgraph.graph
+  }
+
+  final def diff(g1: N3js#Graph, g2: N3js#Graph): N3js#Graph = {
+    val mgraph = makeMGraph(g1)
+    try { removeTriples(mgraph, g2.triples) } catch { case nsee: NoSuchElementException => () }
+    mgraph.graph
+  }
+
+  // graph isomorphism
+
+  final val iso = new GraphIsomorphism[N3js](
+    new SimpleMappingGenerator[N3js](VerticeCBuilder.simpleHash(this))(this)
+  )(this)
+
+  final def isomorphism(left: N3js#Graph, right: N3js#Graph): Boolean = {
+    iso.findAnswer(left, right).isSuccess
+  }
+
+}
+

--- a/N3.js/src/main/scala/org/w3/banana/n3js/model.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/model.scala
@@ -1,0 +1,7 @@
+package org.w3.banana
+package n3js
+package model
+
+final class MGraph[S, P, O](var graph: plantain.model.Graph[S, P, O])
+
+final case class BNode(label: String)

--- a/N3.js/src/main/scala/org/w3/banana/n3js/model.scala
+++ b/N3.js/src/main/scala/org/w3/banana/n3js/model.scala
@@ -1,6 +1,5 @@
 package org.w3.banana
 package n3js
-package model
 
 final class MGraph[S, P, O](var graph: plantain.model.Graph[S, P, O])
 

--- a/N3.js/src/test/scala/org/w3/banana/n3js/N3jsTest.scala
+++ b/N3.js/src/test/scala/org/w3/banana/n3js/N3jsTest.scala
@@ -1,0 +1,35 @@
+package org.w3.banana
+package n3js
+
+object N3jsOpsTest extends RDFOpsTest[N3js]
+
+object N3jsGraphTest extends GraphTest[N3js]
+
+object N3jsMGraphTest extends MGraphTest[N3js]
+
+object N3jsGraphUnionTest extends GraphUnionTest[N3js]
+
+import org.w3.banana.isomorphism._
+
+object N3jsIsomorphismsTest extends IsomorphismTest[N3js]
+
+object N3jsPointedGraphTest extends PointedGraphTest[N3js]
+
+import org.w3.banana.diesel._
+
+object N3jsDieselGraphConstructTest extends DieselGraphConstructTest[N3js]
+
+object N3jsDieselGraphExplorationTest extends DieselGraphExplorationTest[N3js]
+
+import org.w3.banana.binder._
+
+class N3jsCommonBindersTest extends CommonBindersTest[N3js]
+
+class N3jsRecordBinderTest extends RecordBinderTest[N3js]
+
+class N3jsCustomBinderTest extends CustomBindersTest[N3js]
+
+import org.w3.banana.syntax._
+
+// disabled because of https://github.com/scala-js/scala-js/issues/1521
+// class N3jsUriSyntaxTest extends UriSyntaxTest[N3js]

--- a/project/build.scala
+++ b/project/build.scala
@@ -244,11 +244,11 @@ object BananaRdfBuild extends Build {
     .settings(
       Seq(
         //scalaJSStage in Test := FastOptStage,
-        jsDependencies += "org.webjars" % "N3.js" % "799fee7697"/ "n3-browser.min.js" commonJSName "N3",
+        jsDependencies += "org.webjars" % "N3.js" % "9a8de1fc6c"/ "n3-browser.min.js" commonJSName "N3",
         skip in packageJSDependencies := false
       ) ++ zcheckJsSettings : _*
     )
-    .dependsOn(rdf_js, rdfTestSuite_js % "test-internal->compile", plantain_js % "test-internal->compile")
+    .dependsOn(rdf_js, plantain_common_js, rdfTestSuite_js % "test-internal->compile", plantain_js % "test-internal->compile")
 
   /** `jsonld.js`, a js only module binding jsonld.js into banana-rdf abstractions. */
   lazy val jsonldJsM  = CrossModule(SingleBuild,

--- a/project/build.scala
+++ b/project/build.scala
@@ -248,7 +248,7 @@ object BananaRdfBuild extends Build {
         skip in packageJSDependencies := false
       ) ++ zcheckJsSettings : _*
     )
-    .dependsOn(rdf_js, plantain_common_js, rdfTestSuite_js % "test-internal->compile", plantain_js % "test-internal->compile")
+    .dependsOn(rdf_js, plantain_js, rdfTestSuite_js % "test-internal->compile", plantain_js % "test-internal->compile")
 
   /** `jsonld.js`, a js only module binding jsonld.js into banana-rdf abstractions. */
   lazy val jsonldJsM  = CrossModule(SingleBuild,


### PR DESCRIPTION
I hit a [major issue](https://github.com/scala-js/scala-js/issues/1521) with `java.net.URI`'s support for Unicode support so plantain-js is basically not usable in practice for now. I had to take another approach to have something workable in JS, hence this PR.

N3.js recently (in 0.4.2) added helper methods to create objects for the internal representation. That's what I am using here. Note that only URI and Literal make use of that. Helpers for blank nodes are not yet exposed so I am using something similar to Plantain. The RDF graph still uses the Plantain immutable implementation (hence the dependency on the `plantain_common_js`).

All the common tests pass but one related to hash-URIs, which I deactivated, because of https://github.com/scala-js/scala-js/issues/1521.
