### PR TITLE
[build] force the use of sbt-scalajs 0.6.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,8 @@ resolvers += Resolver.url(
 
 addSbtPlugin("com.github.inthenow" % "sbt-scalajs" % "0.6.1")
 
+dependencyOverrides += "org.scala-js" % "sbt-scalajs" % "0.6.0"
+
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")


### PR DESCRIPTION
Looks like sbt-scalajs 0.6.1 makes the build fail. This forcing the use of sbt-scalajs 0.6.0.
