### PR TITLE
fix that allows to import the project to the latest Intellij

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/build.scala
+++ b/project/build.scala
@@ -13,11 +13,12 @@ object BuildSettings {
 
   val buildSettings = publicationSettings ++ defaultScalariformSettings ++ Seq(
     organization := "org.w3",
-    scalaVersion := "2.11.5",
-    crossScalaVersions := Seq("2.11.5", "2.10.4"),
+    scalaVersion := "2.11.6",
+    crossScalaVersions := Seq("2.11.6", "2.10.4"),
     javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
     fork := false,
     parallelExecution in Test := false,
+    publishArtifact in Test := true,
     offline := true,
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-optimize", "-feature", "-language:implicitConversions,higherKinds", "-Xmax-classfile-name", "140", "-Yinline-warnings"),
     scalacOptions in(Compile, doc) := Seq("-groups", "-implicits"),


### PR DESCRIPTION
There is a bug in latest intellij Idea that does not allow to import banana-rdf sbt project ( I reported it there https://youtrack.jetbrains.com/issue/SCL-8594
 ). The problem is that it tries to resolve subprojects from the web instead of taking their compiled versions. Publish-local usually fixes this problem well, but not in this case because some projects depend on % "test" configuration of other projects, that is why publish in Test := true is required
