### PR TITLE
updated dependencies + ugly build fix

### DIFF
--- a/N3.js/src/test/scala/org/w3/banana/n3js/N3Test.scala
+++ b/N3.js/src/test/scala/org/w3/banana/n3js/N3Test.scala
@@ -1,7 +1,7 @@
 package org.w3.banana
 package n3js
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import scala.scalajs.js
 
 import scalajs.concurrent.JSExecutionContext.Implicits.runNow

--- a/N3.js/src/test/scala/org/w3/banana/n3js/io/N3jsTurtleParserTest.scala
+++ b/N3.js/src/test/scala/org/w3/banana/n3js/io/N3jsTurtleParserTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana
 package n3js
 package io
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import scalajs.concurrent.JSExecutionContext.Implicits.runNow
 import org.w3.banana.plantain._
 

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/JsonLdJsTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/JsonLdJsTest.scala
@@ -1,7 +1,7 @@
 package org.w3.banana
 package jsonldjs
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import scala.scalajs.js
 
 import scalajs.concurrent.JSExecutionContext.Implicits.runNow

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana
 package jsonldjs
 package io
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import scalajs.concurrent.JSExecutionContext.Implicits.runNow
 import org.w3.banana.plantain._
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
     * @see http://scalaz.org
     * @see http://repo1.maven.org/maven2/org/scalaz/
     */
-  val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.0"
+  val scalaz = "org.scalaz" %% "scalaz-core" % "7.1.1"
 
   /**
    * scalaz for scalajs
@@ -22,8 +22,7 @@ object Dependencies {
    * @see http://repo1.maven.org/maven2/com/github/japgolly/fork/scalaz
    */
   // Todo: %%%! --> %%%
-  //val scalaz_js = Seq(libraryDependencies += "com.github.japgolly.fork.scalaz" %%%! "scalaz-core" % "7.1.0-4")
-  val scalaz_js = Seq(libraryDependencies += "com.github.inthenow" %%%! "scalaz-core" % "7.1.0-4")
+  val scalaz_js = Seq(libraryDependencies += "com.github.japgolly.fork.scalaz" %%%! "scalaz-core" % "7.1.1-2")
 
   /**
    * joda-Time
@@ -44,10 +43,10 @@ object Dependencies {
    * @see http://www.scalatest.org
    * @see http://repo1.maven.org/maven2/org/scalatest
    */
-  val scalatest = "org.scalatest" %% "scalatest" % "2.2.0"
+  val scalatest = "org.scalatest" %% "scalatest" % "2.2.4"
 
-  
-  /** ScalaCheck
+
+   /** ScalaCheck
     * @see http://scalacheck.org/
     * @see http://repo1.maven.org/maven2/org/scalacheck/
     */
@@ -56,19 +55,25 @@ object Dependencies {
   //Todo:
   val scalacheckJs = Seq(libraryDependencies += "com.github.inthenow" %%%! "scalacheck" % "1.12.2")
 
+  val zcheckJs =  Seq(
+    libraryDependencies += "com.github.inthenow" %%% "zcheck" % "0.6.2"
+  )
+
   val zcheckJsSettings = Seq(
     resolvers += Resolver.url("inthenow-releases", url("http://dl.bintray.com/inthenow/releases"))(Resolver.ivyStylePatterns),
-    libraryDependencies += "com.github.inthenow" %%% "zcheck" % "0.6.0",
+    libraryDependencies += "com.github.inthenow" %%% "zcheck" % "0.6.2",
     testFrameworks := Seq(new TestFramework("org.scalacheck.ScalaCheckFramework"))
   ) ++ scalacheckJs
 
+  val zcheckJvm = "com.github.inthenow" %% "zcheck" % "0.6.2"
+
   val zcheckJvmSettings = Seq(
     resolvers += Resolver.url("inthenow-releases", url("http://dl.bintray.com/inthenow/releases"))(Resolver.ivyStylePatterns),
-    libraryDependencies += "com.github.inthenow" %% "zcheck" % "0.6.0",
+    libraryDependencies += "com.github.inthenow" %% "zcheck" % "0.6.2",
     libraryDependencies += scalacheck,
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-maxSize", "5", "-minSuccessfulTests", "33", "-workers", "1", "-verbosity", "1")
   )
-
+  
   /**
    * Akka Http Core
    * @see http://akka.io
@@ -102,7 +107,7 @@ object Dependencies {
    * @see http://www.openrdf.org/
    * @see http://repo1.maven.org/maven2/org/openrdf/sesame/
    */
-  val sesameVersion = "2.8.0-beta2"
+  val sesameVersion = "2.8.3"
 
 
   val sesameQueryAlgebra = "org.openrdf.sesame" % "sesame-queryalgebra-evaluation" % sesameVersion

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ resolvers += Resolver.url(
 
 addSbtPlugin("com.github.inthenow" % "sbt-scalajs" % "0.6.2")
 
-dependencyOverrides += "org.scala-js" % "sbt-scalajs" % "0.6.0"
+dependencyOverrides += "org.scala-js" % "sbt-scalajs" % "0.6.3"
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/GraphTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/GraphTest.scala
@@ -1,7 +1,7 @@
 package org.w3.banana
 
 import org.w3.banana.diesel._
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class GraphTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {
 

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/GraphUnionTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/GraphUnionTest.scala
@@ -1,6 +1,6 @@
 package org.w3.banana
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import org.w3.banana.diesel._
 
 abstract class GraphUnionTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/MGraphTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/MGraphTest.scala
@@ -1,6 +1,6 @@
 package org.w3.banana
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class MGraphTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {
 

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/PointedGraphTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/PointedGraphTest.scala
@@ -1,6 +1,6 @@
 package org.w3.banana
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 /**
  *  see org.w3.banana.binder.CommonBindersTest for more tests

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/RDFOpsTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/RDFOpsTest.scala
@@ -1,6 +1,6 @@
 package org.w3.banana
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class RDFOpsTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {
 

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/SpecLiteExtra.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/SpecLiteExtra.scala
@@ -1,6 +1,6 @@
 package org.w3.banana
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 trait SpecLiteExtra { self: SpecLite =>
 

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/binder/CommonBindersTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/binder/CommonBindersTest.scala
@@ -1,8 +1,8 @@
 package org.w3.banana.binder
 
+import com.inthenow.zcheck.SpecLite
 import org.w3.banana._, syntax._, diesel._
 import scala.util._
-import zcheck.SpecLite
 
 class CommonBindersTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {
 

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/binder/RecordBinderTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/binder/RecordBinderTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana.binder
 
 import org.w3.banana._, syntax._, diesel._
 import scala.util._
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class RecordBinderTest[Rdf <: RDF](implicit
   ops: RDFOps[Rdf],

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/diesel/DieselGraphConstructTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/diesel/DieselGraphConstructTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana.diesel
 
 import org.w3.banana._
 import org.w3.banana.syntax._
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import scalaz.Scalaz.{ none, some }
 
 class DieselGraphConstructTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/diesel/DieselGraphExplorationTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/diesel/DieselGraphExplorationTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana.diesel
 
 import org.w3.banana._
 import org.w3.banana.syntax._
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import scala.util._
 
 class DieselGraphExplorationTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/diesel/DieselOwlPrimerTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/diesel/DieselOwlPrimerTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana.diesel
 
 import org.w3.banana._
 import org.w3.banana.syntax._
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import scalaz.Scalaz.{ none, some }
 import org.w3.banana.PointedGraphs
 

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/io/SerialisationTestSuite.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/io/SerialisationTestSuite.scala
@@ -2,7 +2,7 @@ package org.w3.banana
 package io
 
 import java.io._
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 import org.w3.banana.{ Prefix, RDF, RDFOps }
 import scalaz._
 import scalaz.syntax._, monad._, comonad._

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/isomorphism/IsomorphismTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/isomorphism/IsomorphismTest.scala
@@ -1,7 +1,7 @@
 package org.w3.banana.isomorphism
 
 import org.w3.banana._
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 /**
  * Generic Tests for  isomorphism functions that use whatever the Ops implementation chooses

--- a/rdf-test-suite/common/src/main/scala/org/w3/banana/syntax/UriSyntaxTest.scala
+++ b/rdf-test-suite/common/src/main/scala/org/w3/banana/syntax/UriSyntaxTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana.syntax
 
 import org.w3.banana._
 import java.net.URL
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class UriSyntaxTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {
 

--- a/rdf-test-suite/js/src/main/scala/org/w3/banana/binder/CustomBindersTest.scala
+++ b/rdf-test-suite/js/src/main/scala/org/w3/banana/binder/CustomBindersTest.scala
@@ -3,7 +3,7 @@ package org.w3.banana.binder
 import org.w3.banana._, syntax._, diesel._
 import scala.util._
 
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class CustomBindersTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {
 

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/binder/CustomBindersTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/binder/CustomBindersTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana.binder
 
 import org.w3.banana._, syntax._, diesel._
 import scala.util._
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class CustomBindersTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {
 

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/binder/RecordBinderJvmTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/binder/RecordBinderJvmTest.scala
@@ -4,7 +4,7 @@ import org.w3.banana._, syntax._, diesel._
 import scala.util._
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPublicKey
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class RecordBinderJvmTest[Rdf <: RDF](implicit
                                    ops: RDFOps[Rdf],

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/syntax/UriSyntaxJvmTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/syntax/UriSyntaxJvmTest.scala
@@ -2,7 +2,7 @@ package org.w3.banana.syntax
 
 import org.w3.banana._
 import java.net.URL
-import zcheck.SpecLite
+import com.inthenow.zcheck.SpecLite
 
 class UriSyntaxJvmTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends SpecLite {
 

--- a/sesame/src/main/scala/org/w3/banana/sesame/SesameOps.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/SesameOps.scala
@@ -167,7 +167,7 @@ class SesameOps extends RDFOps[Sesame] with SesameMGraphOps with DefaultURIOps[S
   def isomorphism(left: Sesame#Graph, right: Sesame#Graph): Boolean = {
     val leftNoContext = left.asScala.map(s => makeTriple(s.getSubject, s.getPredicate, s.getObject)).asJava
     val rightNoContext = right.asScala.map(s => makeTriple(s.getSubject, s.getPredicate, s.getObject)).asJava
-    ModelUtil.equals(leftNoContext, rightNoContext)
+    Models.isomorphic(leftNoContext, rightNoContext)
   }
 
   def graphSize(g: Sesame#Graph): Int = g.size()


### PR DESCRIPTION
At the moment banana-rdf is not usable as both Intellij and Eclipse imports are broken. Here I updated some of the dependencies and introduced dirty fixes that make it possible to import the project to IDEs. @InTheNow will be very busy during next several weeks so I suggest to use dirty fix as a temporal solution before he will find some time to fist the bug in sbt-scalajs plugin ( I opened an issue about this https://github.com/InTheNow/sbt-scalajs/issues/17 )
