### PR TITLE
moved to akka-http 1.0-RC3 and removed redundant imports

### DIFF
--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/Plantain.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/Plantain.scala
@@ -1,7 +1,7 @@
 package org.w3.banana.plantain
 
+import akka.http.scaladsl.model.Uri
 import org.w3.banana._
-import akka.http.model.Uri
 
 /** A Scala-based RDF implementation that limits boxing.
   */

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainOps.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainOps.scala
@@ -1,10 +1,10 @@
 package org.w3.banana.plantain
 
-import org.w3.banana._
-import akka.http.model.Uri
-import java.util.UUID
-import org.w3.banana.isomorphism._
 import java.math.BigInteger
+
+import akka.http.scaladsl.model.Uri
+import org.w3.banana._
+import org.w3.banana.isomorphism._
 
 object PlantainOps extends RDFOps[Plantain] with PlantainMGraphOps with PlantainURIOps {
 

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainURIOps.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainURIOps.scala
@@ -1,8 +1,7 @@
 package org.w3.banana.plantain
 
+import akka.http.scaladsl.model.Uri
 import org.w3.banana._
-import org.w3.banana.plantain.model._
-import akka.http.model.Uri
 
 trait PlantainURIOps extends URIOps[Plantain] {
 
@@ -34,7 +33,7 @@ trait PlantainURIOps extends URIOps[Plantain] {
   // TODO should rely on a spray.http.Uri when https://github.com/spray/spray/issues/818 is addressed
   // for implementation algorithm, see https://github.com/stain/cxf/blob/trunk/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/HttpUtils.java
   def relativize(uri: Plantain#URI, other: Plantain#URI): Plantain#URI = {
-    import java.net.{ URI => jURI }
+    import java.net.{URI => jURI}
     val juri = new jURI(uri.toString).relativize(new jURI(other.toString))
     Uri(juri.toString)
   }

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/Util.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/Util.scala
@@ -1,14 +1,8 @@
 package org.w3.banana.plantain
 
-import java.io.{ ByteArrayOutputStream, OutputStream }
-import java.net.{ URI => jURI } //we use jURIs because the correctly work with relative Uris
-import akka.http.model.Uri
+import akka.http.scaladsl.model.Uri
 import org.openrdf.model.impl._
-import org.openrdf.rio.turtle._
-import org.openrdf.{ model => sesame }
-import org.w3.banana.plantain._
-import org.w3.banana.io._
-import scala.util.Try
+import org.openrdf.{model => sesame}
 
 
 object Util {

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFReader.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFReader.scala
@@ -2,7 +2,7 @@ package org.w3.banana.plantain
 package io
 
 import java.io.{ Reader, InputStream }
-import akka.http.model.Uri
+import akka.http.scaladsl.model.Uri
 import org.openrdf.rio._
 import org.openrdf.rio.turtle._
 import org.openrdf.{ model => sesame }

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
@@ -1,13 +1,14 @@
 package org.w3.banana.plantain.io
 
-import java.io.{ ByteArrayOutputStream, OutputStream }
-import java.net.{ URI => jURI } //we use jURIs because the correctly work with relative Uris
-import akka.http.model.Uri
+import java.io.{ByteArrayOutputStream, OutputStream}
+import java.net.{URI => jURI}
+
 import org.openrdf.model.impl._
 import org.openrdf.rio.turtle._
-import org.openrdf.{ model => sesame }
-import org.w3.banana.plantain._
+import org.openrdf.{model => sesame}
 import org.w3.banana.io._
+import org.w3.banana.plantain._
+
 import scala.util.Try
 
 object PlantainTurtleWriter extends RDFWriter[Plantain, Try, Turtle] {

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/model/model.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/model/model.scala
@@ -1,7 +1,6 @@
 package org.w3.banana.plantain.model
 
-import org.w3.banana._
-import akka.http.model.Uri
+import akka.http.scaladsl.model.Uri
 
 final class MGraph[S, P, O](var graph: Graph[S, P, O])
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
    * @see http://akka.io
    * @see http://repo1.maven.org/maven2/com/typesafe/akka
    */
-  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core-experimental" % "0.9"
+  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core-experimental" % "1.0-RC3"
 
   /**
    * jena

--- a/project/build.scala
+++ b/project/build.scala
@@ -24,8 +24,8 @@ object BuildSettings {
     scalacOptions in(Compile, doc) := Seq("-groups", "-implicits"),
     description := "RDF framework for Scala",
     startYear := Some(2012),
-    resolvers += Resolver.bintrayRepo("inthenow","releases")
-    
+    resolvers += Resolver.bintrayRepo("inthenow","releases"),
+    updateOptions := updateOptions.value.withCachedResolution(true) //to speed up dependency resolution
   )
 }
 


### PR DESCRIPTION
I moved to akka-http 1.0-RC3 and removed redundant imports. 
I also added     updateOptions := updateOptions.value.withCachedResolution(true)  to speed up dependency resolution as it takes a lot of time and slows down development. I also recommend to clean all target folders after git pull
