### PR TITLE
banana-rdf Scalatex website

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -7,6 +7,7 @@ import com.typesafe.sbt.SbtScalariform.defaultScalariformSettings
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import sbtunidoc.Plugin._
 import ScalaJSPlugin.autoImport._
+import scalatex.ScalatexReadme
 
 object BuildSettings {
   import Publishing._
@@ -310,4 +311,12 @@ object BananaRdfBuild extends Build {
 
   lazy val experimental = experimentalM.project(Module, ldpatch)
 
+
+  /** Scalatex banana-rdf website, see http://lihaoyi.github.io/Scalatex/#QuickStart */
+  lazy val readme = scalatex.ScalatexReadme(
+    projectId = "readme",
+    wd = file(""),
+    url = "https://github.com/lihaoyi/scalatex/tree/master",
+    source = "Readme"
+  )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 
 dependencyOverrides += "org.scala-js" % "sbt-scalajs" % "0.6.3"
+
+addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.1") //for documentation

--- a/readme/.gitignore
+++ b/readme/.gitignore
@@ -1,0 +1,6 @@
+# Ignore generated files
+*
+# except for scalatex files
+!.scalatex
+#and .gitignore itself
+!.gitignore

--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -1,0 +1,55 @@
+@import Main._
+@sect{Banana-RDF}
+  @p
+    banana-rdf is a library for RDF, SPARQL and Linked Data technologies in Scala.
+
+  @p
+    It can be used with existing libraries without any added cost.
+    There is no wrapping involved: you manipulate directly the real objects.
+    We currently support Jena, Sesame and Plantain, a pure Scala implementation.
+
+  @sect{Features}
+    @p
+      banana-rdf emphasizes type-safety and immutability, so it can come with some cost when the underlying implementation is very mutable (I'm looking at you, Jena and Sesame). We try to keep a clear distinction between the core concepts and the enhanced syntax that Scala can give us.
+    @p
+      RDF itself is defined as a record of types. Implementations just have to plug their own types. And because types alone are not enough, we introduce the RDFOps typeclass, which defines the mandatory operations that an RDF implementation must implement. SparqlOps does the same for SPARQL.
+    @p
+      With banana-rdf, you get Diesel, a nice DSL to build and navigate within pointed graphs (graphs with a pointer to an inner node). You also get an abstraction for graph stores (GraphStore), which do not have to be SPARQL engines (SparqlEngine). Of course, you can serialize and deserialize most of the RDF syntaxes as well as JSON-LD (RDFa will come soon).
+    @p
+      banana-rdf introduces the concept of binders, which let you bridge the Scala and RDF worlds. Most of the common datastructures are already available, and you can even map your own classes. Unlike usual ORM techniques, this does not rely on annotation or reflection.
+    @p
+      Until we write thorough documentation, the best place to understand what you can do is to go through the test suite.
+
+  @sect{Usage}
+
+    @p
+      You only need a recent version of Java and an @a("SBT",href:="http://www.scala-sbt.org/") installed , that's all:
+
+    @div
+      @hl.sh
+        $ git clone https://github.com/w3c/banana-rdf/
+        $ cd banana-rdf
+        $ sbt
+    @p
+      It's also easy to just build specific target platforms:
+
+    @div
+      @hl.sh
+        $ sbt +banana_js/test    # for javascript only
+        $ sbt +banana_jvm/test   # for jvm only
+
+  @sect{Community}
+    @p
+      For discussions that don't fit in @a("the issues tracker", href:="https://github.com/w3c/banana-rdf/issues"), you may try:
+    @ul
+      @li
+        the w3c banana-rdf @a("mailing list", href := "http://lists.w3.org/Archives/Public/public-banana-rdf/"), for longer discussions
+      @li
+        the banana-rdf @a("gitter channel", href := "https://gitter.im/w3c/banana-rdf")
+    @b
+      Banana-RDF contributors all agree to follow the @a("W3C Code of Ethics and Professional Conduct", href := "http://www.w3.org/Consortium/cepc/").
+
+  @sect{Licence}
+    @p
+      This source code is made available under the @a("W3C Licence", href := "http://opensource.org/licenses/W3C"). This is a business friendly license.
+


### PR DESCRIPTION
Scalatex is an sbt plugin that generates statis websites from .scalatex files. Famous HandsOnScala ( http://lihaoyi.github.io/hands-on-scala-js/ ) as well as documentation for many scalajs libs (like http://scala-js.github.io/scala-js-dom/ ) and scalatex itself ( http://lihaoyi.github.io/Scalatex/#AdvancedTechniques  ) are made by scalatex.

I think it will fit very well for banana-rdf because:
- a nice looking website ads creditibility to the web
- it is well structured and easy manageable
- there are some cool features in scalatex like insertion of code samples from real source code (that means we will not need to update all examples manualy after some small source changes)
- we can add scala and scalajs code directed to scalatex files
