### PR TITLE
Add option to print RDF with prefixes applied in the turtle output.

### DIFF
--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
@@ -6,7 +6,9 @@ import java.io.{Writer => jWriter, _}
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.rdf.model.impl.RDFWriterFImpl
 import org.apache.jena.rdfxml.xmloutput.impl.Abbreviated
+import org.apache.jena.shared.PrefixMapping
 import org.apache.jena.riot.{Lang => JenaLang, RDFWriter=>_, _}
+import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.jena.Jena.ops._
 
@@ -19,12 +21,12 @@ object JenaRDFWriter {
 
   private [JenaRDFWriter] def makeRDFWriter[S](lang: JenaLang): RDFWriter[Jena, Try, S] = new RDFWriter[Jena, Try, S] {
 
-    def write(graph: Jena#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
       val model = ModelFactory.createModelForGraph(graph)
       writerFactory.getWriter(lang.getLabel).write(model, os, base)
     }
 
-    def asString(graph: Jena#Graph, base: String): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
       val result = new StringWriter()
       val model = ModelFactory.createModelForGraph(graph)
       writerFactory.getWriter(lang.getLabel).write(model, result, base)
@@ -34,14 +36,14 @@ object JenaRDFWriter {
 
   val rdfxmlWriter: RDFWriter[Jena, Try, RDFXML] = new RDFWriter[Jena, Try, RDFXML] {
 
-    def write(graph: Jena#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
       val writer = new Abbreviated()
       writer.setProperty("relativeURIs", "same-document,relative")
       val model = ModelFactory.createModelForGraph(graph)
       writer.write(model, os, base)
     }
 
-    def asString(graph: Jena#Graph, base: String): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
       val result = new StringWriter()
       val writer = new Abbreviated()
       writer.setProperty("relativeURIs", "same-document,relative")
@@ -56,14 +58,26 @@ object JenaRDFWriter {
 
     // with the turtle writer we pass it  relative graph as that seems to stop the parser from adding the
     // @base statement at the top!
-    def write(graph: Jena#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
       val relativeGraph = graph.relativize(URI(base))
+
+      val mapping: PrefixMapping = relativeGraph.getPrefixMapping
+      prefixes.foreach { p =>
+        mapping.setNsPrefix(p.prefixName, p.prefixIri)
+      }
+
       RDFDataMgr.write(os, relativeGraph, JenaLang.TURTLE)
     }
 
-    def asString(graph: Jena#Graph, base: String): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
       val result = new StringWriter()
       val relativeGraph = graph.relativize(URI(base))
+
+      val mapping: PrefixMapping = relativeGraph.getPrefixMapping
+      prefixes.foreach {p =>
+        mapping.setNsPrefix(p.prefixName, p.prefixIri)
+      }
+
       RDFDataMgr.write(result, relativeGraph, JenaLang.TURTLE)
       result.toString()
     }

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
@@ -21,12 +21,12 @@ object JenaRDFWriter {
 
   private [JenaRDFWriter] def makeRDFWriter[S](lang: JenaLang): RDFWriter[Jena, Try, S] = new RDFWriter[Jena, Try, S] {
 
-    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Jena]]): Try[Unit] = Try {
       val model = ModelFactory.createModelForGraph(graph)
       writerFactory.getWriter(lang.getLabel).write(model, os, base)
     }
 
-    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Set[Prefix[Jena]]): Try[String] = Try {
       val result = new StringWriter()
       val model = ModelFactory.createModelForGraph(graph)
       writerFactory.getWriter(lang.getLabel).write(model, result, base)
@@ -36,14 +36,14 @@ object JenaRDFWriter {
 
   val rdfxmlWriter: RDFWriter[Jena, Try, RDFXML] = new RDFWriter[Jena, Try, RDFXML] {
 
-    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Jena]]): Try[Unit] = Try {
       val writer = new Abbreviated()
       writer.setProperty("relativeURIs", "same-document,relative")
       val model = ModelFactory.createModelForGraph(graph)
       writer.write(model, os, base)
     }
 
-    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Set[Prefix[Jena]]): Try[String] = Try {
       val result = new StringWriter()
       val writer = new Abbreviated()
       writer.setProperty("relativeURIs", "same-document,relative")
@@ -58,7 +58,7 @@ object JenaRDFWriter {
 
     // with the turtle writer we pass it  relative graph as that seems to stop the parser from adding the
     // @base statement at the top!
-    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Jena]]): Try[Unit] = Try {
       val relativeGraph = graph.relativize(URI(base))
 
       val mapping: PrefixMapping = relativeGraph.getPrefixMapping
@@ -69,7 +69,7 @@ object JenaRDFWriter {
       RDFDataMgr.write(os, relativeGraph, JenaLang.TURTLE)
     }
 
-    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Set[Prefix[Jena]]): Try[String] = Try {
       val result = new StringWriter()
       val relativeGraph = graph.relativize(URI(base))
 

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -4,11 +4,10 @@ import org.w3.banana.Prefix
 import org.w3.banana.io.{NTriplesReaderTestSuite, RdfXMLTestSuite, TurtleTestSuite, RDFWriter}
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
-import scalaz.syntax._, comonad._
 
 class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
   "write with prefixes" in {
-    val prefix = Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/")
+    val prefix = Set(Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/"))
 
 //    val expectedString =
 //      """
@@ -18,14 +17,14 @@ class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
 //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
 //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
 
-    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    val withPrefix = writer.asString(referenceGraph, "", prefix).get
     withPrefix should include("@prefix foo:")
     withPrefix should include("foo:creator")
     withPrefix should include("foo:publisher")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
 
-    val noPrefix = writer.asString(referenceGraph, "").copoint
+    val noPrefix = writer.asString(referenceGraph, "").get
     noPrefix should not include ("@prefix foo:")
     noPrefix should not include ("foo:creator")
     noPrefix should not include ("foo:publisher")

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -1,38 +1,13 @@
 package org.w3.banana.jena
 
-import org.w3.banana.Prefix
-import org.w3.banana.io.{NTriplesReaderTestSuite, RdfXMLTestSuite, TurtleTestSuite, RDFWriter}
-import scala.util.Try
+import org.w3.banana.io.{NTriplesReaderTestSuite, PrefixTestSuite, RdfXMLTestSuite, TurtleTestSuite}
 import org.w3.banana.util.tryInstances._
 
-class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
-  "write with prefixes" in {
-    val prefix = Set(Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/"))
+import scala.util.Try
 
-//    val expectedString =
-//      """
-//        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
-//        |
-//        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
-//        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
-//        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
+class JenaTurtleTest extends TurtleTestSuite[Jena, Try]
 
-    val withPrefix = writer.asString(referenceGraph, "", prefix).get
-    withPrefix should include("@prefix foo:")
-    withPrefix should include("foo:creator")
-    withPrefix should include("foo:publisher")
-    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
-    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
-
-    val noPrefix = writer.asString(referenceGraph, "").get
-    noPrefix should not include ("@prefix foo:")
-    noPrefix should not include ("foo:creator")
-    noPrefix should not include ("foo:publisher")
-    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
-    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
-
-  }
-}
+class JenaPrefixTest extends PrefixTestSuite[Jena, Try]
 
 class JenaNTripleReaderTestSuite extends NTriplesReaderTestSuite[Jena]
 

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -10,29 +10,28 @@ class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
   "write with prefixes" in {
     val prefix = Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/")
 
-    val sout = writer.asString(referenceGraph, "", prefix).copoint
-//    val expected =
-//      """@prefix foo:   <http://purl.org/dc/elements/1.1/> .
+//    val expectedString =
+//      """
+//        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
 //        |
 //        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
 //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
 //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
-//    sout must_== expected // TODO this doesn't work as expected for some reason
 
-    val l: Iterator[String] = sout.lines
-    l.next() must_== """@prefix foo:   <http://purl.org/dc/elements/1.1/> ."""
-    l.next() must_== """"""
-    l.next() must_== """<http://www.w3.org/2001/sw/RDFCore/ntriples/>"""
-    l.next() must_== """        foo:creator    "Dave Beckett" , "Art Barstow" ;"""
-    l.next() must_== """        foo:publisher  <http://www.w3.org/> ."""
+    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    withPrefix should include("@prefix foo:")
+    withPrefix should include("foo:creator")
+    withPrefix should include("foo:publisher")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
 
-    val noPrefix2 = writer.asString(referenceGraph, "").copoint
-    val l2 = noPrefix2.lines
-    l2.next() must_== """<http://www.w3.org/2001/sw/RDFCore/ntriples/>"""
-    l2.next() must_== """        <http://purl.org/dc/elements/1.1/creator>"""
-    l2.next() must_== """                "Dave Beckett" , "Art Barstow" ;"""
-    l2.next() must_== """        <http://purl.org/dc/elements/1.1/publisher>"""
-    l2.next() must_== """                <http://www.w3.org/> ."""
+    val noPrefix = writer.asString(referenceGraph, "").copoint
+    noPrefix should not include ("@prefix foo:")
+    noPrefix should not include ("foo:creator")
+    noPrefix should not include ("foo:publisher")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
+
   }
 }
 

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -1,11 +1,42 @@
 package org.w3.banana.jena
 
-import org.w3.banana.io.{NTriplesReaderTestSuite, RdfXMLTestSuite, TurtleTestSuite}
+import org.w3.banana.Prefix
+import org.w3.banana.io.{NTriplesReaderTestSuite, RdfXMLTestSuite, TurtleTestSuite, RDFWriter}
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
+import scalaz.syntax._, comonad._
 
-class JenaTurtleTest extends TurtleTestSuite[Jena, Try]
+class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
+  "write with prefixes" in {
+    val prefix = Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/")
+
+    val sout = writer.asString(referenceGraph, "", prefix).copoint
+//    val expected =
+//      """@prefix foo:   <http://purl.org/dc/elements/1.1/> .
+//        |
+//        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
+//        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
+//        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
+//    sout must_== expected // TODO this doesn't work as expected for some reason
+
+    val l: Iterator[String] = sout.lines
+    l.next() must_== """@prefix foo:   <http://purl.org/dc/elements/1.1/> ."""
+    l.next() must_== """"""
+    l.next() must_== """<http://www.w3.org/2001/sw/RDFCore/ntriples/>"""
+    l.next() must_== """        foo:creator    "Dave Beckett" , "Art Barstow" ;"""
+    l.next() must_== """        foo:publisher  <http://www.w3.org/> ."""
+
+    val noPrefix2 = writer.asString(referenceGraph, "").copoint
+    val l2 = noPrefix2.lines
+    l2.next() must_== """<http://www.w3.org/2001/sw/RDFCore/ntriples/>"""
+    l2.next() must_== """        <http://purl.org/dc/elements/1.1/creator>"""
+    l2.next() must_== """                "Dave Beckett" , "Art Barstow" ;"""
+    l2.next() must_== """        <http://purl.org/dc/elements/1.1/publisher>"""
+    l2.next() must_== """                <http://www.w3.org/> ."""
+  }
+}
 
 class JenaNTripleReaderTestSuite extends NTriplesReaderTestSuite[Jena]
 
 class JenaRdfXMLTest extends RdfXMLTestSuite[Jena, Try]
+

--- a/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
+++ b/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
@@ -54,7 +54,7 @@ trait IOExample extends IOExampleDependencies {
     val graphAsXMLString = rdfXMLWriter.asString(graph10Triples, base = timblCard) getOrElse sys.error("coudn't serialize the graph")
     println(graphAsXMLString)
 
-    val graphAsTurtleString = turtleWriter.asString(graph10Triples, base = timblCard, foaf, rdf) getOrElse sys.error("coudn't serialize the graph")
+    val graphAsTurtleString = turtleWriter.asString(graph10Triples, base = timblCard, Set(foaf, rdf)) getOrElse sys.error("coudn't serialize the graph")
     println(graphAsTurtleString)
   }
 

--- a/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
+++ b/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
@@ -10,6 +10,7 @@ trait IOExampleDependencies
   extends RDFModule
   with RDFOpsModule
   with TurtleReaderModule
+  with TurtleWriterModule
   with RDFXMLWriterModule
 
 /* Here is an example doing some IO. Read below to see what's
@@ -45,11 +46,16 @@ trait IOExample extends IOExampleDependencies {
     if (ret.isSuccess)
       println(s"successfuly wrote TimBL's card to ${tmpFile.getAbsolutePath}")
 
+    val foaf = FOAFPrefix[Rdf]
+    val rdf = RDFSPrefix[Rdf]
     /* prints 10 triples to stdout */
 
     val graph10Triples = Graph(graph.triples.take(10).toSet)
-    val graphAsString = rdfXMLWriter.asString(graph10Triples, base = timblCard) getOrElse sys.error("coudn't serialize the graph")
-    println(graphAsString)
+    val graphAsXMLString = rdfXMLWriter.asString(graph10Triples, base = timblCard) getOrElse sys.error("coudn't serialize the graph")
+    println(graphAsXMLString)
+
+    val graphAsTurtleString = turtleWriter.asString(graph10Triples, base = timblCard, foaf, rdf) getOrElse sys.error("coudn't serialize the graph")
+    println(graphAsTurtleString)
   }
 
 }

--- a/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
+++ b/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
@@ -2,7 +2,7 @@ package org.w3.banana.io
 
 import java.io.OutputStream
 
-import org.w3.banana.{RDF, RDFOps}
+import org.w3.banana.{Prefix, RDF, RDFOps}
 
 import scala.util.Try
 
@@ -33,14 +33,14 @@ class NTriplesWriter[Rdf <: RDF](implicit val ops:RDFOps[Rdf]) extends RDFWriter
     }
   )
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Prefix[Rdf]*): Try[Unit] = Try {
     for (triple <- graph.triples) {
       val line = tripleAsString(triple) + "\r\n"
       os.write(line.getBytes("UTF-8"))
     }
   }
 
-  def asString(graph: Rdf#Graph, base: String): Try[String] = Try{
+  def asString(graph: Rdf#Graph, base: String, prefixes: Prefix[Rdf]*): Try[String] = Try{
     (
       for ( triple <- ops.getTriples(graph))
       yield tripleAsString(triple)

--- a/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
+++ b/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
@@ -33,14 +33,14 @@ class NTriplesWriter[Rdf <: RDF](implicit val ops:RDFOps[Rdf]) extends RDFWriter
     }
   )
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Prefix[Rdf]*): Try[Unit] = Try {
+  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Rdf]]): Try[Unit] = Try {
     for (triple <- graph.triples) {
       val line = tripleAsString(triple) + "\r\n"
       os.write(line.getBytes("UTF-8"))
     }
   }
 
-  def asString(graph: Rdf#Graph, base: String, prefixes: Prefix[Rdf]*): Try[String] = Try{
+  def asString(graph: Rdf#Graph, base: String, prefixes: Set[Prefix[Rdf]]): Try[String] = Try{
     (
       for ( triple <- ops.getTriples(graph))
       yield tripleAsString(triple)

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
@@ -67,12 +67,12 @@ object PlantainTurtleWriter extends RDFWriter[Plantain, Try, Turtle] {
 
   }
 
-  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String, prefixes: Prefix[Plantain]*): Try[Unit] = {
+  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String, prefixes: Set[Prefix[Plantain]]): Try[Unit] = {
     val writer = new Writer(graph, outputstream, base)
     writer.write()
   }
 
-  def asString(graph: Plantain#Graph, base: String, prefixes: Prefix[Plantain]*): Try[String] = Try {
+  def asString(graph: Plantain#Graph, base: String, prefixes: Set[Prefix[Plantain]]): Try[String] = Try {
     val result = new ByteArrayOutputStream()
     val writer = new Writer(graph, result, base)
     writer.write()

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
@@ -6,6 +6,7 @@ import java.net.{URI => jURI}
 import org.openrdf.model.impl._
 import org.openrdf.rio.turtle._
 import org.openrdf.{model => sesame}
+import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.plantain._
 
@@ -66,12 +67,12 @@ object PlantainTurtleWriter extends RDFWriter[Plantain, Try, Turtle] {
 
   }
 
-  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String): Try[Unit] = {
+  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String, prefixes: Prefix[Plantain]*): Try[Unit] = {
     val writer = new Writer(graph, outputstream, base)
     writer.write()
   }
 
-  def asString(graph: Plantain#Graph, base: String): Try[String] = Try {
+  def asString(graph: Plantain#Graph, base: String, prefixes: Prefix[Plantain]*): Try[String] = Try {
     val result = new ByteArrayOutputStream()
     val writer = new Writer(graph, result, base)
     writer.write()

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/PrefixTestSuite.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/PrefixTestSuite.scala
@@ -1,0 +1,45 @@
+package org.w3.banana.io
+
+import org.w3.banana.{Prefix, RDF, RDFOps}
+
+import scalaz._, scalaz.syntax.comonad._
+
+abstract class PrefixTestSuite[Rdf <: RDF, M[+ _] : Monad : Comonad](implicit
+  ops: RDFOps[Rdf],
+  reader: RDFReader[Rdf, M, Turtle],
+  val writer: RDFWriter[Rdf, M, Turtle]
+) extends SerialisationTestSuite[Rdf, M, Turtle, Turtle]("Turtle", "ttl") {
+  val referenceGraphSerialisedForSyntax =
+    """
+<http://www.w3.org/2001/sw/RDFCore/ntriples/> <http://purl.org/dc/elements/1.1/creator> "Dave Beckett", "Art Barstow" ;
+                                              <http://purl.org/dc/elements/1.1/publisher> <http://www.w3.org/> .
+  """
+
+  "write with prefixes" in {
+    val prefix = Set(Prefix[Rdf]("foo", "http://purl.org/dc/elements/1.1/"))
+
+    //    val expectedString =
+    //      """
+    //        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
+    //        |
+    //        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
+    //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
+    //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
+
+    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    withPrefix should include("@prefix foo:")
+    withPrefix should include("foo:creator")
+    withPrefix should include("foo:publisher")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
+
+    val noPrefix = writer.asString(referenceGraph, "").copoint
+    noPrefix should not include ("@prefix foo:")
+    noPrefix should not include ("foo:creator")
+    noPrefix should not include ("foo:publisher")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
+
+  }
+
+}

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/TurtleTestSuite.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/TurtleTestSuite.scala
@@ -6,7 +6,7 @@ import scalaz._
 abstract class TurtleTestSuite[Rdf <: RDF, M[+_] : Monad : Comonad](implicit
   ops: RDFOps[Rdf],
   reader: RDFReader[Rdf, M, Turtle],
-  writer: RDFWriter[Rdf, M, Turtle]
+  val writer: RDFWriter[Rdf, M, Turtle]
 ) extends SerialisationTestSuite[Rdf, M, Turtle, Turtle]("Turtle", "ttl") {
 
   val referenceGraphSerialisedForSyntax = """

--- a/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
@@ -5,10 +5,12 @@ import java.io.OutputStream
 
 trait RDFWriter[Rdf <: RDF, M[_], +T] extends Writer[Rdf#Graph,M,T] {
 
+  def write(graph: Rdf#Graph, os: OutputStream, base: String): M[Unit] = write(graph, os, base, Nil:_*)
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String): M[Unit]
+  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Prefix[Rdf]*): M[Unit]
 
-  def asString(graph: Rdf#Graph, base: String): M[String]
+  def asString(graph: Rdf#Graph, base: String): M[String] = asString(graph, base, Nil:_*)
+
+  def asString(graph: Rdf#Graph, base: String, prefixes: Prefix[Rdf]*): M[String]
 
 }
-

--- a/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
@@ -5,12 +5,12 @@ import java.io.OutputStream
 
 trait RDFWriter[Rdf <: RDF, M[_], +T] extends Writer[Rdf#Graph,M,T] {
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String): M[Unit] = write(graph, os, base, Nil:_*)
+  override def write(obj: Rdf#Graph, os: OutputStream, base: String): M[Unit] = write(obj, os, base, Set())
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Prefix[Rdf]*): M[Unit]
+  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Rdf]]): M[Unit]
 
-  def asString(graph: Rdf#Graph, base: String): M[String] = asString(graph, base, Nil:_*)
+  override def asString(obj: Rdf#Graph, base: String): M[String] = asString(obj, base, Set())
 
-  def asString(graph: Rdf#Graph, base: String, prefixes: Prefix[Rdf]*): M[String]
+  def asString(graph: Rdf#Graph, base: String, prefixes: Set[Prefix[Rdf]]): M[String]
 
 }

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
@@ -1,5 +1,6 @@
 package org.w3.banana.sesame.io
 
+import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.sesame._
 import java.io._
@@ -10,14 +11,14 @@ class SesameRDFWriter[T](implicit
   sesameSyntax: SesameSyntax[T]
 ) extends RDFWriter[Sesame, Try, T] {
 
-  def write(graph: Sesame#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+  def write(graph: Sesame#Graph, os: OutputStream, base: String, prefixes: Prefix[Sesame]*): Try[Unit] = Try {
     val sWriter = sesameSyntax.rdfWriter(os, base)
     sWriter.startRDF()
     ops.getTriples(graph) foreach sWriter.handleStatement
     sWriter.endRDF()
   }
 
-  def asString(graph: Sesame#Graph, base: String): Try[String] = Try {
+  def asString(graph: Sesame#Graph, base: String, prefixes: Prefix[Sesame]*): Try[String] = Try {
     val result = new StringWriter()
     val sWriter = sesameSyntax.rdfWriter(result, base)
     sWriter.startRDF()

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
@@ -13,6 +13,9 @@ class SesameRDFWriter[T](implicit
 
   def write(graph: Sesame#Graph, os: OutputStream, base: String, prefixes: Prefix[Sesame]*): Try[Unit] = Try {
     val sWriter = sesameSyntax.rdfWriter(os, base)
+    prefixes.foreach(p => {
+      sWriter.handleNamespace(p.prefixName, p.prefixIri)
+    })
     sWriter.startRDF()
     ops.getTriples(graph) foreach sWriter.handleStatement
     sWriter.endRDF()
@@ -21,6 +24,9 @@ class SesameRDFWriter[T](implicit
   def asString(graph: Sesame#Graph, base: String, prefixes: Prefix[Sesame]*): Try[String] = Try {
     val result = new StringWriter()
     val sWriter = sesameSyntax.rdfWriter(result, base)
+    prefixes.foreach(p => {
+      sWriter.handleNamespace(p.prefixName, p.prefixIri)
+    })
     sWriter.startRDF()
     ops.getTriples(graph) foreach sWriter.handleStatement
     sWriter.endRDF()

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
@@ -11,7 +11,7 @@ class SesameRDFWriter[T](implicit
   sesameSyntax: SesameSyntax[T]
 ) extends RDFWriter[Sesame, Try, T] {
 
-  def write(graph: Sesame#Graph, os: OutputStream, base: String, prefixes: Prefix[Sesame]*): Try[Unit] = Try {
+  def write(graph: Sesame#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Sesame]]): Try[Unit] = Try {
     val sWriter = sesameSyntax.rdfWriter(os, base)
     prefixes.foreach(p => {
       sWriter.handleNamespace(p.prefixName, p.prefixIri)
@@ -21,7 +21,7 @@ class SesameRDFWriter[T](implicit
     sWriter.endRDF()
   }
 
-  def asString(graph: Sesame#Graph, base: String, prefixes: Prefix[Sesame]*): Try[String] = Try {
+  def asString(graph: Sesame#Graph, base: String, prefixes: Set[Prefix[Sesame]]): Try[String] = Try {
     val result = new StringWriter()
     val sWriter = sesameSyntax.rdfWriter(result, base)
     prefixes.foreach(p => {

--- a/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
+++ b/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
@@ -1,41 +1,14 @@
 package org.w3.banana.sesame.io
 
-import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.sesame._
-
-import scala.util.Try
 import org.w3.banana.util.tryInstances._
 
-class SesameTurtleTests extends TurtleTestSuite[Sesame, Try] {
+import scala.util.Try
 
-  "write with prefixes" in {
-    val prefix = Set(Prefix[Sesame]("foo", "http://purl.org/dc/elements/1.1/"))
+class SesameTurtleTests extends TurtleTestSuite[Sesame, Try]
 
-    //    val expectedString =
-    //      """
-    //        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
-    //        |
-    //        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
-    //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
-    //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
-
-    val withPrefix = writer.asString(referenceGraph, "", prefix).get
-    withPrefix should include("@prefix foo:")
-    withPrefix should include("foo:creator")
-    withPrefix should include("foo:publisher")
-    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
-    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
-
-    val noPrefix = writer.asString(referenceGraph, "").get
-    noPrefix should not include ("@prefix foo:")
-    noPrefix should not include ("foo:creator")
-    noPrefix should not include ("foo:publisher")
-    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
-    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
-
-  }
-}
+class SesamePrefixTest extends PrefixTestSuite[Sesame, Try]
 
 class SesameNTripleReaderTestSuite extends NTriplesReaderTestSuite[Sesame]
 

--- a/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
+++ b/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
@@ -6,12 +6,11 @@ import org.w3.banana.sesame._
 
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
-import scalaz.syntax._, comonad._
 
 class SesameTurtleTests extends TurtleTestSuite[Sesame, Try] {
 
   "write with prefixes" in {
-    val prefix = Prefix[Sesame]("foo", "http://purl.org/dc/elements/1.1/")
+    val prefix = Set(Prefix[Sesame]("foo", "http://purl.org/dc/elements/1.1/"))
 
     //    val expectedString =
     //      """
@@ -21,14 +20,14 @@ class SesameTurtleTests extends TurtleTestSuite[Sesame, Try] {
     //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
     //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
 
-    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    val withPrefix = writer.asString(referenceGraph, "", prefix).get
     withPrefix should include("@prefix foo:")
     withPrefix should include("foo:creator")
     withPrefix should include("foo:publisher")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
 
-    val noPrefix = writer.asString(referenceGraph, "").copoint
+    val noPrefix = writer.asString(referenceGraph, "").get
     noPrefix should not include ("@prefix foo:")
     noPrefix should not include ("foo:creator")
     noPrefix should not include ("foo:publisher")

--- a/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
+++ b/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
@@ -1,11 +1,42 @@
 package org.w3.banana.sesame.io
 
+import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.sesame._
+
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
+import scalaz.syntax._, comonad._
 
-class SesameTurtleTests extends TurtleTestSuite[Sesame, Try]
+class SesameTurtleTests extends TurtleTestSuite[Sesame, Try] {
+
+  "write with prefixes" in {
+    val prefix = Prefix[Sesame]("foo", "http://purl.org/dc/elements/1.1/")
+
+    //    val expectedString =
+    //      """
+    //        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
+    //        |
+    //        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
+    //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
+    //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
+
+    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    withPrefix should include("@prefix foo:")
+    withPrefix should include("foo:creator")
+    withPrefix should include("foo:publisher")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
+
+    val noPrefix = writer.asString(referenceGraph, "").copoint
+    noPrefix should not include ("@prefix foo:")
+    noPrefix should not include ("foo:creator")
+    noPrefix should not include ("foo:publisher")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
+
+  }
+}
 
 class SesameNTripleReaderTestSuite extends NTriplesReaderTestSuite[Sesame]
 


### PR DESCRIPTION
Currently implemented in the Jena writer module, stubs only in the other modules.
