### PR TITLE
Read language-tagged string as a literal string.

### DIFF
--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/CommonBindersTest.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/CommonBindersTest.scala
@@ -32,6 +32,18 @@ class CommonBindersTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends WordSpec 
     pg123.toPG.as[Int] shouldEqual Success(123)
   }
 
+  "serializing and deserializing a String" in {
+    val pgString = "abc".toPG
+    pgString.pointer shouldEqual (Literal("abc", xsd.string))
+    pgString.graph shouldEqual (Graph.empty)
+    pgString.toPG.as[String] shouldEqual (Success("abc"))
+
+    val taggedLiteral = makeLangTaggedLiteral("abcEng", Lang("en")).toPG
+    taggedLiteral.pointer shouldEqual (Literal.tagged("abcEng", Lang("en")))
+    taggedLiteral.graph shouldEqual (Graph.empty)
+    taggedLiteral.toPG.as[String] shouldEqual (Success("abcEng"))
+  }
+
   "serializing and deserializing a List of simple nodes" in {
     val bn1 = BNode()
     val bn2 = BNode()

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/FromLiteral.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/FromLiteral.scala
@@ -20,7 +20,7 @@ object FromLiteral {
     import ops._
     def fromLiteral(literal: Rdf#Literal): Try[String] = {
       val Literal(lexicalForm, datatype, _) = literal
-      if (datatype == xsd.string)
+      if (datatype == xsd.string || datatype == rdf.langString)
         Success(lexicalForm)
       else
         Failure(FailedConversion(s"${literal} is not an xsd:string"))


### PR DESCRIPTION
Read a language-tagged string as a literal string. Reading a tagged string as a Binder property failed before adding this.
