### PR TITLE
added option to publish to private repo with ssh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ banana-rdf
 
 [![Build Status](https://secure.travis-ci.org/w3c/banana-rdf.png)](http://travis-ci.org/w3c/banana-rdf) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/w3c/banana-rdf?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+The current published version 0.9.0-SNAPSHOT for scala 2.12 is to be found on the [http://bblfish.net/work/repo/snapshots](bblfish.net/work/repo/snapshots) repository.
+
+```scala
+val banana = (name: String) => "org.w3" %% name % "0.9.0-SNAPSHOT" excludeAll (ExclusionRule(organization = "org.scala-stm"))
+
+//add the bblfish-snapshots repository to the resolvers
+
+resolvers += "bblfish-snapshots" at "http://bblfish.net/work/repo/snapshots"
+
+//choose the packages you need for your dependencies
+val bananaDeps = Seq("banana", "banana-rdf", "banana-sesame").map(banana)
+```
+
 An RDF library in Scala
 -----------------------
 
@@ -110,19 +123,8 @@ $ sbt eclipse
 IntelliJ IDEA
 -------------
 
-IntelliJ IDEA works with just one global change:
+IntelliJ IDEA works out of the box since 2016.
 
-In `~/.sbt/0.13/plugins/build.sbt`
-
-```
-    addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
-```
-
-To generate IntelliJ project files, just run the command:
-
-``` bash
-$ sbt gen-idea
-```
 
 Community
 =========
@@ -130,7 +132,7 @@ Community
 For discussions that don't fit in the [issues tracker](https://github.com/w3c/banana-rdf/issues), you may try
 either 
 *  the [w3c banana-rdf mailing list](http://lists.w3.org/Archives/Public/public-banana-rdf/), for longer discussions
-*  the banana-rdf irc channel on freenode using a dedicated IRC client connecting to [irc://irc.freenode.net:6667/banana-rdf](irc://irc.freenode.net:6667/banana-rdf) or using the [freenode html interface](http://webchat.freenode.net), for quick real time socialising
+*  the [banana-rdf gitter channel](https://gitter.im/banana-rdf/banana-rdf), for quick real time socialising
 
 Code of Conduct
 ---------------

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ banana-rdf
 
 [![Build Status](https://secure.travis-ci.org/w3c/banana-rdf.png)](http://travis-ci.org/w3c/banana-rdf) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/w3c/banana-rdf?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The current published version 0.9.0-SNAPSHOT for scala 2.12 is to be found on the [http://bblfish.net/work/repo/snapshots](bblfish.net/work/repo/snapshots) repository.
+The current published version 0.8.4-SNAPSHOT for scala 2.12 is to be found on the [http://bblfish.net/work/repo/snapshots](bblfish.net/work/repo/snapshots) repository.
 
 ```scala
-val banana = (name: String) => "org.w3" %% name % "0.9.0-SNAPSHOT" excludeAll (ExclusionRule(organization = "org.scala-stm"))
+val banana = (name: String) => "org.w3" %% name % "0.8.4-SNAPSHOT" excludeAll (ExclusionRule(organization = "org.scala-stm"))
 
 //add the bblfish-snapshots repository to the resolvers
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,17 +33,38 @@ lazy val pomSettings = Seq(
   licenses +=("W3C", url("http://opensource.org/licenses/W3C"))
 )
 
-lazy val publicationSettings = pomSettings ++ Seq(
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-  },
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-  publishArtifact in Test := false
-)
+//sbt -Dbanana.publish=bblfish.net:/home/hjs/htdocs/work/repo/
+//sbt -Dbanana.publish=bintray
+lazy val publicationSettings = pomSettings ++ {
+  val pubre = """([^:]+):([^:]+)""".r
+  Option(System.getProperty("banana.publish")) match {
+    case Some("bintray") | None => Seq(
+// removed due to issue https://github.com/typesafehub/dbuild/issues/158
+//      publishTo := {
+//        val nexus = "https://oss.sonatype.org/"
+//        if (isSnapshot.value)
+//          Some("snapshots" at nexus + "content/repositories/snapshots")
+//        else
+//          Some("releases" at nexus + "service/local/staging/deploy/maven2")
+//      },
+//      releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+//      publishArtifact in Test := false
+    )
+    case Some(pubre(host, path)) =>
+      Seq(
+        publishTo := Some(
+          Resolver.ssh("banana.publish specified server",
+            host,
+            path + {
+              if (isSnapshot.value) "snapshots" else "releases"
+            }
+          )
+        ),
+        publishArtifact in Test := false
+      )
+    case other => Seq()
+  }
+}
 
 lazy val commonSettings = publicationSettings ++ defaultScalariformSettings ++ Seq(
   organization := "org.w3",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,17 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+/**
+  * Bintray pluging
+  *
+  * @see https://github.com/softprops/bintray-sbt
+  *
+  * note: there seems to be a problem with this plugin, in that it does not work
+  * well with other publications methods.  So we'll disable it for the moment.
+  * @see https://github.com/sbt/sbt-testng/issues/4
+  * @see https://github.com/typesafehub/dbuild/issues/158
+  */
+//addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 /**
   * ScalaJS sbt plugin

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.0-SNAPSHOT"
+version in ThisBuild := "0.8.4-SNAPSHOT"


### PR DESCRIPTION
But: this does not work with bintray which somehow always overrides all other options. See issue reference in code committed here.
Used this to publish this branch of 2.12 code to http://bblfish.net/work/repo/snapshots/org/w3/