### PR TITLE
Start 0.8.5-SNAPSHOT

### DIFF
--- a/jena/src/main/scala/org/w3/banana/jena/JenaModule.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaModule.scala
@@ -17,6 +17,7 @@ with SparqlHttpModule
 with RDFXMLReaderModule
 with TurtleReaderModule
 with NTriplesReaderModule
+with JsonLDReaderModule
 with NTriplesWriterModule
 with RDFXMLWriterModule
 with TurtleWriterModule
@@ -57,6 +58,8 @@ with XmlQueryResultsReaderModule {
   implicit val n3Writer: RDFWriter[Jena, Try, N3] = JenaRDFWriter.n3Writer
 
   implicit val ntriplesWriter: RDFWriter[Jena, Try, NTriples] = new NTriplesWriter[Jena]
+
+  implicit val jsonldReader: RDFReader[Rdf, Try, JsonLd] = JenaRDFReader.jsonLdReader
 
   implicit val jsonSolutionsWriter: SparqlSolutionsWriter[Jena, SparqlAnswerJson] =
     JenaSolutionsWriter.solutionsWriterJson

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFReader.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFReader.scala
@@ -3,10 +3,14 @@ package org.w3.banana.jena.io
 import org.apache.jena.graph.{Node => JenaNode, Triple => JenaTriple, _}
 import org.apache.jena.rdf.model.{RDFReader => _}
 import java.io._
+import java.nio.charset.Charset
+
+import org.apache.commons.io.input.ReaderInputStream
 import org.apache.jena.riot._
 import org.apache.jena.riot.system._
 import org.w3.banana.io._
 import org.w3.banana.jena.{Jena, JenaOps}
+
 import scala.util._
 
 /** A triple sink that accumulates triples in a graph. */
@@ -50,13 +54,14 @@ object JenaRDFReader {
 
     def read(is: InputStream, base: String): Try[Jena#Graph] = Try {
       val sink = new TripleSink
-      RDFParser.create().lang(lang).source(is).base(base).parse(sink)
+      RDFParser.create().source(is).lang(lang).base(base).parse(sink)
       sink.graph
     }
 
     def read(reader: Reader, base: String): Try[Jena#Graph] = Try {
       val sink = new TripleSink
-      RDFDataMgr.parse(sink, reader.asInstanceOf[StringReader], base, lang)
+      // why is Jena deprecating Readers, which should be the correct level to parse character based documents?
+      RDFParser.create().source(new ReaderInputStream(reader,Charset.forName("utf-8"))).lang(lang).base(base).parse(sink)
       sink.graph
     }
   }

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFReader.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFReader.scala
@@ -47,12 +47,10 @@ final class TripleSink(implicit ops: JenaOps) extends StreamRDF {
 object JenaRDFReader {
 
   def makeRDFReader[S](ops: JenaOps, lang: Lang): RDFReader[Jena, Try, S] = new RDFReader[Jena, Try, S] {
-    val factory = RDFParserRegistry.getFactory(lang)
 
     def read(is: InputStream, base: String): Try[Jena#Graph] = Try {
       val sink = new TripleSink
-      factory.create(lang).read(is, base, null, sink, null)
-      //      RDFDataMgr.parse(sink, is, base, lang)
+      RDFParser.create().lang(lang).source(is).base(base).parse(sink)
       sink.graph
     }
 
@@ -69,4 +67,5 @@ object JenaRDFReader {
 
   implicit def n3Reader()(implicit ops: JenaOps): RDFReader[Jena, Try, N3] = makeRDFReader[N3](ops, Lang.N3)
 
+  implicit def jsonLdReader()(implicit ops: JenaOps): RDFReader[Jena,Try,JsonLd] = makeRDFReader[JsonLd](ops,Lang.JSONLD)
 }

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
@@ -6,7 +6,7 @@ import java.io.{Writer => jWriter, _}
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.rdf.model.impl.RDFWriterFImpl
 import org.apache.jena.rdfxml.xmloutput.impl.Abbreviated
-import org.apache.jena.riot.{Lang => JenaLang, _}
+import org.apache.jena.riot.{Lang => JenaLang, RDFWriter=>_, _}
 import org.w3.banana.io._
 import org.w3.banana.jena.Jena.ops._
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,7 +50,11 @@ object Dependencies {
    * @see https://jena.apache.org/
    * @see http://repo1.maven.org/maven2/org/apache/jena
    */
-  val jenaLibs = "org.apache.jena" % "apache-jena-libs" % "3.1.1"
+// this does not work with  version 1.0.0 of Ammonite
+// https://github.com/lihaoyi/Ammonite/issues/664
+// val jenaLibs = "org.apache.jena" % "apache-jena-libs" % "3.1.1"
+// the following downloads more, so it would be nice to be able to come back to previous unless more is needed
+   val jenaLibs = "org.apache.jena" % "jena-tdb" % "3.3.0"
 
   /**
    * logback for jena

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,11 +50,7 @@ object Dependencies {
    * @see https://jena.apache.org/
    * @see http://repo1.maven.org/maven2/org/apache/jena
    */
-// this does not work with  version 1.0.0 of Ammonite
-// https://github.com/lihaoyi/Ammonite/issues/664
-// val jenaLibs = "org.apache.jena" % "apache-jena-libs" % "3.1.1"
-// the following downloads more, so it would be nice to be able to come back to previous unless more is needed
-   val jenaLibs = "org.apache.jena" % "jena-tdb" % "3.4.0"
+ val jenaLibs = "org.apache.jena" % "apache-jena-libs" % "3.4.0"
 
   /**
    * logback for jena

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,7 @@ object Dependencies {
 // https://github.com/lihaoyi/Ammonite/issues/664
 // val jenaLibs = "org.apache.jena" % "apache-jena-libs" % "3.1.1"
 // the following downloads more, so it would be nice to be able to come back to previous unless more is needed
-   val jenaLibs = "org.apache.jena" % "jena-tdb" % "3.3.0"
+   val jenaLibs = "org.apache.jena" % "jena-tdb" % "3.4.0"
 
   /**
    * logback for jena
@@ -105,7 +105,7 @@ object Dependencies {
    * @see http://jena.apache.org/documentation/serving_data
    * @see http://repo1.maven.org/maven2/org/apache/jena/jena-fuseki/
    */
-  val fusekiVersion =  "2.4.1"
+  val fusekiVersion =  "3.4.0"
   val fuseki = "org.apache.jena" % "apache-jena-fuseki" % fusekiVersion
   val fusekiServer = "org.apache.jena" % "jena-fuseki-server" % fusekiVersion
 

--- a/rdf/shared/src/main/scala/org/w3/banana/io/Syntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/Syntax.scala
@@ -12,6 +12,6 @@ trait SparqlAnswerJson
 trait SparqlAnswerXml
 
 trait JsonLd
-trait JsonLdCompacted
-trait JsonLdExpanded
-trait JsonLdFlattened
+trait JsonLdCompacted extends JsonLd
+trait JsonLdExpanded extends JsonLd
+trait JsonLdFlattened extends JsonLd

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.4"
+version in ThisBuild := "0.8.5-SNAPSHOT"


### PR DESCRIPTION
* Add JSonLDReader for Jena which now supports it
* Change a method that was deprecated in Jena
* Update Jena to 3.4.0
* tie the JSONLD Syntaxes back together with a super trait, as this is needed to make it not overly tedious to write code to tie the banana-syntax notation to something more useful such as the akka mime types as in [RdfMediaTypes](https://github.com/read-write-web/solid-client/blob/bb76372a3e59f56e64fb81e18701e000de7f2d34/src/main/scala/run/cosy/solid/RdfMediaTypes.scala#L66)
