### PR TITLE
Hexastore in Plantain Implementation

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+This work is being provided by the copyright holders under the [W3C Software and Document Short Notice](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
+
+License
+
+By obtaining and/or copying this work, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.
+
+Permission to copy, modify, and distribute this work, with or without modification, for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the work or portions thereof, including modifications:
+
+    The full text of this NOTICE in a location viewable to users of the redistributed or derivative work.
+    Any pre-existing intellectual property disclaimers, notices, or terms and conditions. If none exist, the W3C Software and Document Short Notice should be included.
+    Notice of any changes or modifications, through a copyright statement on the new code or document such as "This software or document includes material copied from or derived from [title and URI of the W3C document]. Copyright © [YEAR] W3C® (MIT, ERCIM, Keio, Beihang)." 
+
+Disclaimers
+
+THIS WORK IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR DOCUMENT WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR DOCUMENT.
+
+The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to the work without specific, written prior permission. Title to copyright in this work will at all times remain with copyright holders.

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
@@ -6,7 +6,9 @@ import java.io.{Writer => jWriter, _}
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.rdf.model.impl.RDFWriterFImpl
 import org.apache.jena.rdfxml.xmloutput.impl.Abbreviated
+import org.apache.jena.shared.PrefixMapping
 import org.apache.jena.riot.{Lang => JenaLang, RDFWriter=>_, _}
+import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.jena.Jena.ops._
 
@@ -19,12 +21,12 @@ object JenaRDFWriter {
 
   private [JenaRDFWriter] def makeRDFWriter[S](lang: JenaLang): RDFWriter[Jena, Try, S] = new RDFWriter[Jena, Try, S] {
 
-    def write(graph: Jena#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
       val model = ModelFactory.createModelForGraph(graph)
       writerFactory.getWriter(lang.getLabel).write(model, os, base)
     }
 
-    def asString(graph: Jena#Graph, base: String): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
       val result = new StringWriter()
       val model = ModelFactory.createModelForGraph(graph)
       writerFactory.getWriter(lang.getLabel).write(model, result, base)
@@ -34,14 +36,14 @@ object JenaRDFWriter {
 
   val rdfxmlWriter: RDFWriter[Jena, Try, RDFXML] = new RDFWriter[Jena, Try, RDFXML] {
 
-    def write(graph: Jena#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
       val writer = new Abbreviated()
       writer.setProperty("relativeURIs", "same-document,relative")
       val model = ModelFactory.createModelForGraph(graph)
       writer.write(model, os, base)
     }
 
-    def asString(graph: Jena#Graph, base: String): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
       val result = new StringWriter()
       val writer = new Abbreviated()
       writer.setProperty("relativeURIs", "same-document,relative")
@@ -56,14 +58,26 @@ object JenaRDFWriter {
 
     // with the turtle writer we pass it  relative graph as that seems to stop the parser from adding the
     // @base statement at the top!
-    def write(graph: Jena#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
       val relativeGraph = graph.relativize(URI(base))
+
+      val mapping: PrefixMapping = relativeGraph.getPrefixMapping
+      prefixes.foreach { p =>
+        mapping.setNsPrefix(p.prefixName, p.prefixIri)
+      }
+
       RDFDataMgr.write(os, relativeGraph, JenaLang.TURTLE)
     }
 
-    def asString(graph: Jena#Graph, base: String): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
       val result = new StringWriter()
       val relativeGraph = graph.relativize(URI(base))
+
+      val mapping: PrefixMapping = relativeGraph.getPrefixMapping
+      prefixes.foreach {p =>
+        mapping.setNsPrefix(p.prefixName, p.prefixIri)
+      }
+
       RDFDataMgr.write(result, relativeGraph, JenaLang.TURTLE)
       result.toString()
     }

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaRDFWriter.scala
@@ -21,12 +21,12 @@ object JenaRDFWriter {
 
   private [JenaRDFWriter] def makeRDFWriter[S](lang: JenaLang): RDFWriter[Jena, Try, S] = new RDFWriter[Jena, Try, S] {
 
-    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Jena]]): Try[Unit] = Try {
       val model = ModelFactory.createModelForGraph(graph)
       writerFactory.getWriter(lang.getLabel).write(model, os, base)
     }
 
-    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Set[Prefix[Jena]]): Try[String] = Try {
       val result = new StringWriter()
       val model = ModelFactory.createModelForGraph(graph)
       writerFactory.getWriter(lang.getLabel).write(model, result, base)
@@ -36,14 +36,14 @@ object JenaRDFWriter {
 
   val rdfxmlWriter: RDFWriter[Jena, Try, RDFXML] = new RDFWriter[Jena, Try, RDFXML] {
 
-    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Jena]]): Try[Unit] = Try {
       val writer = new Abbreviated()
       writer.setProperty("relativeURIs", "same-document,relative")
       val model = ModelFactory.createModelForGraph(graph)
       writer.write(model, os, base)
     }
 
-    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Set[Prefix[Jena]]): Try[String] = Try {
       val result = new StringWriter()
       val writer = new Abbreviated()
       writer.setProperty("relativeURIs", "same-document,relative")
@@ -58,7 +58,7 @@ object JenaRDFWriter {
 
     // with the turtle writer we pass it  relative graph as that seems to stop the parser from adding the
     // @base statement at the top!
-    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Prefix[Jena]*): Try[Unit] = Try {
+    def write(graph: Jena#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Jena]]): Try[Unit] = Try {
       val relativeGraph = graph.relativize(URI(base))
 
       val mapping: PrefixMapping = relativeGraph.getPrefixMapping
@@ -69,7 +69,7 @@ object JenaRDFWriter {
       RDFDataMgr.write(os, relativeGraph, JenaLang.TURTLE)
     }
 
-    def asString(graph: Jena#Graph, base: String, prefixes: Prefix[Jena]*): Try[String] = Try {
+    def asString(graph: Jena#Graph, base: String, prefixes: Set[Prefix[Jena]]): Try[String] = Try {
       val result = new StringWriter()
       val relativeGraph = graph.relativize(URI(base))
 

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -4,11 +4,10 @@ import org.w3.banana.Prefix
 import org.w3.banana.io.{NTriplesReaderTestSuite, RdfXMLTestSuite, TurtleTestSuite, RDFWriter}
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
-import scalaz.syntax._, comonad._
 
 class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
   "write with prefixes" in {
-    val prefix = Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/")
+    val prefix = Set(Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/"))
 
 //    val expectedString =
 //      """
@@ -18,14 +17,14 @@ class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
 //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
 //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
 
-    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    val withPrefix = writer.asString(referenceGraph, "", prefix).get
     withPrefix should include("@prefix foo:")
     withPrefix should include("foo:creator")
     withPrefix should include("foo:publisher")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
 
-    val noPrefix = writer.asString(referenceGraph, "").copoint
+    val noPrefix = writer.asString(referenceGraph, "").get
     noPrefix should not include ("@prefix foo:")
     noPrefix should not include ("foo:creator")
     noPrefix should not include ("foo:publisher")

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -1,38 +1,13 @@
 package org.w3.banana.jena
 
-import org.w3.banana.Prefix
-import org.w3.banana.io.{NTriplesReaderTestSuite, RdfXMLTestSuite, TurtleTestSuite, RDFWriter}
-import scala.util.Try
+import org.w3.banana.io.{NTriplesReaderTestSuite, PrefixTestSuite, RdfXMLTestSuite, TurtleTestSuite}
 import org.w3.banana.util.tryInstances._
 
-class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
-  "write with prefixes" in {
-    val prefix = Set(Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/"))
+import scala.util.Try
 
-//    val expectedString =
-//      """
-//        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
-//        |
-//        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
-//        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
-//        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
+class JenaTurtleTest extends TurtleTestSuite[Jena, Try]
 
-    val withPrefix = writer.asString(referenceGraph, "", prefix).get
-    withPrefix should include("@prefix foo:")
-    withPrefix should include("foo:creator")
-    withPrefix should include("foo:publisher")
-    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
-    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
-
-    val noPrefix = writer.asString(referenceGraph, "").get
-    noPrefix should not include ("@prefix foo:")
-    noPrefix should not include ("foo:creator")
-    noPrefix should not include ("foo:publisher")
-    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
-    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
-
-  }
-}
+class JenaPrefixTest extends PrefixTestSuite[Jena, Try]
 
 class JenaNTripleReaderTestSuite extends NTriplesReaderTestSuite[Jena]
 

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -10,29 +10,28 @@ class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
   "write with prefixes" in {
     val prefix = Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/")
 
-    val sout = writer.asString(referenceGraph, "", prefix).copoint
-//    val expected =
-//      """@prefix foo:   <http://purl.org/dc/elements/1.1/> .
+//    val expectedString =
+//      """
+//        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
 //        |
 //        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
 //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
 //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
-//    sout must_== expected // TODO this doesn't work as expected for some reason
 
-    val l: Iterator[String] = sout.lines
-    l.next() must_== """@prefix foo:   <http://purl.org/dc/elements/1.1/> ."""
-    l.next() must_== """"""
-    l.next() must_== """<http://www.w3.org/2001/sw/RDFCore/ntriples/>"""
-    l.next() must_== """        foo:creator    "Dave Beckett" , "Art Barstow" ;"""
-    l.next() must_== """        foo:publisher  <http://www.w3.org/> ."""
+    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    withPrefix should include("@prefix foo:")
+    withPrefix should include("foo:creator")
+    withPrefix should include("foo:publisher")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
 
-    val noPrefix2 = writer.asString(referenceGraph, "").copoint
-    val l2 = noPrefix2.lines
-    l2.next() must_== """<http://www.w3.org/2001/sw/RDFCore/ntriples/>"""
-    l2.next() must_== """        <http://purl.org/dc/elements/1.1/creator>"""
-    l2.next() must_== """                "Dave Beckett" , "Art Barstow" ;"""
-    l2.next() must_== """        <http://purl.org/dc/elements/1.1/publisher>"""
-    l2.next() must_== """                <http://www.w3.org/> ."""
+    val noPrefix = writer.asString(referenceGraph, "").copoint
+    noPrefix should not include ("@prefix foo:")
+    noPrefix should not include ("foo:creator")
+    noPrefix should not include ("foo:publisher")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
+
   }
 }
 

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -1,11 +1,42 @@
 package org.w3.banana.jena
 
-import org.w3.banana.io.{NTriplesReaderTestSuite, RdfXMLTestSuite, TurtleTestSuite}
+import org.w3.banana.Prefix
+import org.w3.banana.io.{NTriplesReaderTestSuite, RdfXMLTestSuite, TurtleTestSuite, RDFWriter}
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
+import scalaz.syntax._, comonad._
 
-class JenaTurtleTest extends TurtleTestSuite[Jena, Try]
+class JenaTurtleTest extends TurtleTestSuite[Jena, Try] {
+  "write with prefixes" in {
+    val prefix = Prefix[Jena]("foo", "http://purl.org/dc/elements/1.1/")
+
+    val sout = writer.asString(referenceGraph, "", prefix).copoint
+//    val expected =
+//      """@prefix foo:   <http://purl.org/dc/elements/1.1/> .
+//        |
+//        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
+//        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
+//        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
+//    sout must_== expected // TODO this doesn't work as expected for some reason
+
+    val l: Iterator[String] = sout.lines
+    l.next() must_== """@prefix foo:   <http://purl.org/dc/elements/1.1/> ."""
+    l.next() must_== """"""
+    l.next() must_== """<http://www.w3.org/2001/sw/RDFCore/ntriples/>"""
+    l.next() must_== """        foo:creator    "Dave Beckett" , "Art Barstow" ;"""
+    l.next() must_== """        foo:publisher  <http://www.w3.org/> ."""
+
+    val noPrefix2 = writer.asString(referenceGraph, "").copoint
+    val l2 = noPrefix2.lines
+    l2.next() must_== """<http://www.w3.org/2001/sw/RDFCore/ntriples/>"""
+    l2.next() must_== """        <http://purl.org/dc/elements/1.1/creator>"""
+    l2.next() must_== """                "Dave Beckett" , "Art Barstow" ;"""
+    l2.next() must_== """        <http://purl.org/dc/elements/1.1/publisher>"""
+    l2.next() must_== """                <http://www.w3.org/> ."""
+  }
+}
 
 class JenaNTripleReaderTestSuite extends NTriplesReaderTestSuite[Jena]
 
 class JenaRdfXMLTest extends RdfXMLTestSuite[Jena, Try]
+

--- a/jsonld.js/src/main/resources/jsonld.js
+++ b/jsonld.js/src/main/resources/jsonld.js
@@ -3,8 +3,8 @@
  *
  * @author Dave Longley
  *
- * BSD 3-Clause License
- * Copyright (c) 2011-2014 Digital Bazaar, Inc.
+ * @license BSD 3-Clause License
+ * Copyright (c) 2011-2015 Digital Bazaar, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,7 +36,6 @@
 (function() {
 
 // determine if in-browser or using node.js
-//var _nodejs = false;
 var _nodejs = (
   typeof process !== 'undefined' && process.versions && process.versions.node);
 var _browser = !_nodejs &&
@@ -129,12 +128,12 @@ jsonld.compact = function(input, ctx, options, callback) {
   }
 
   var expand = function(input, options, callback) {
-    jsonld.nextTick(function() {
-      if(options.skipExpansion) {
-        return callback(null, input);
-      }
-      jsonld.expand(input, options, callback);
-    });
+    if(options.skipExpansion) {
+      return jsonld.nextTick(function() {
+        callback(null, input);
+      });
+    }
+    jsonld.expand(input, options, callback);
   };
 
   // expand input then do compaction
@@ -290,7 +289,7 @@ jsonld.expand = function(input, options, callback) {
               code: 'loading document failed',
               cause: ex,
               remoteDoc: remoteDoc
-          }));
+            }));
         }
         expand(remoteDoc);
       };
@@ -510,7 +509,7 @@ jsonld.frame = function(input, frame, options, callback) {
               code: 'loading document failed',
               cause: ex,
               remoteDoc: remoteDoc
-          }));
+            }));
         }
         doFrame(remoteDoc);
       };
@@ -732,7 +731,7 @@ jsonld.objectify = function(input, ctx, options, callback) {
         if(!_isArray(types)) {
           types = [types];
         }
-        for(var t in types) {
+        for(var t = 0; t < types.length; ++t) {
           if(!(types[t] in compacted.of_type)) {
             compacted.of_type[types[t]] = [];
           }
@@ -745,13 +744,19 @@ jsonld.objectify = function(input, ctx, options, callback) {
 };
 
 /**
- * Performs RDF dataset normalization on the given JSON-LD input. The output
- * is an RDF dataset unless the 'format' option is used.
+ * Performs RDF dataset normalization on the given input. The input is JSON-LD
+ * unless the 'inputFormat' option is used. The output is an RDF dataset
+ * unless the 'format' option is used.
  *
- * @param input the JSON-LD input to normalize.
+ * @param input the input to normalize as JSON-LD or as a format specified by
+ *          the 'inputFormat' option.
  * @param [options] the options to use:
+ *          [algorithm] the normalization algorithm to use, `URDNA2015` or
+ *            `URGNA2012` (default: `URGNA2012`).
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
+ *          [inputFormat] the format if input is not JSON-LD:
+ *            'application/nquads' for N-Quads.
  *          [format] the format if output is a string:
  *            'application/nquads' for N-Quads.
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
@@ -772,6 +777,9 @@ jsonld.normalize = function(input, options, callback) {
   options = options || {};
 
   // set default options
+  if(!('algorithm' in options)) {
+    options.algorithm = 'URGNA2012';
+  }
   if(!('base' in options)) {
     options.base = (typeof input === 'string') ? input : '';
   }
@@ -779,20 +787,30 @@ jsonld.normalize = function(input, options, callback) {
     options.documentLoader = jsonld.loadDocument;
   }
 
-  // convert to RDF dataset then do normalization
-  var opts = _clone(options);
-  delete opts.format;
-  opts.produceGeneralizedRdf = false;
-  jsonld.toRDF(input, opts, function(err, dataset) {
-    if(err) {
+  if('inputFormat' in options) {
+    if(options.inputFormat !== 'application/nquads') {
       return callback(new JsonLdError(
-        'Could not convert input to RDF dataset before normalization.',
-        'jsonld.NormalizeError', {cause: err}));
+        'Unknown normalization input format.',
+        'jsonld.NormalizeError'));
     }
-
+    var parsedInput = _parseNQuads(input);
     // do normalization
-    new Processor().normalize(dataset, options, callback);
-  });
+    new Processor().normalize(parsedInput, options, callback);
+  } else {
+    // convert to RDF dataset then do normalization
+    var opts = _clone(options);
+    delete opts.format;
+    opts.produceGeneralizedRdf = false;
+    jsonld.toRDF(input, opts, function(err, dataset) {
+      if(err) {
+        return callback(new JsonLdError(
+          'Could not convert input to RDF dataset before normalization.',
+          'jsonld.NormalizeError', {cause: err}));
+      }
+      // do normalization
+      new Processor().normalize(dataset, options, callback);
+    });
+  }
 };
 
 /**
@@ -857,13 +875,22 @@ jsonld.fromRDF = function(dataset, options, callback) {
       };
     }
 
-    // rdf parser may be async or sync, always pass callback
-    dataset = rdfParser(dataset, function(err, dataset) {
-      if(err) {
-        return callback(err);
+    var callbackCalled = false;
+    try {
+      // rdf parser may be async or sync, always pass callback
+      dataset = rdfParser(dataset, function(err, dataset) {
+        callbackCalled = true;
+        if(err) {
+          return callback(err);
+        }
+        fromRDF(dataset, options, callback);
+      });
+    } catch(e) {
+      if(!callbackCalled) {
+        return callback(e);
       }
-      fromRDF(dataset, options, callback);
-    });
+      throw e;
+    }
     // handle synchronous or promise-based parser
     if(dataset) {
       // if dataset is actually a promise
@@ -956,7 +983,8 @@ jsonld.toRDF = function(input, options, callback) {
  * @param [options] the options to use:
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
- *          [namer] a jsonld.UniqueNamer to use to label blank nodes.
+ *          [issuer] a jsonld.IdentifierIssuer to use to label blank nodes.
+ *          [namer] (deprecated)
  *          [documentLoader(url, callback(err, remoteDoc))] the document loader.
  * @param callback(err, nodeMap) called once the operation completes.
  */
@@ -1011,7 +1039,8 @@ jsonld.createNodeMap = function(input, options, callback) {
  * @param [options] the options to use:
  *          [base] the base IRI to use.
  *          [expandContext] a context to expand with.
- *          [namer] a jsonld.UniqueNamer to use to label blank nodes.
+ *          [issuer] a jsonld.IdentifierIssuer to use to label blank nodes.
+ *          [namer] (deprecated).
  *          [mergeNodes] true to merge properties for nodes with the same ID,
  *            false to ignore new properties for nodes with the same ID once
  *            the ID has been defined; note that this may not prevent merging
@@ -1077,7 +1106,7 @@ jsonld.merge = function(docs, ctx, options, callback) {
       mergeNodes = options.mergeNodes;
     }
 
-    var namer = options.namer || new UniqueNamer('_:b');
+    var issuer = options.namer || options.issuer || new IdentifierIssuer('_:b');
     var graphs = {'@default': {}};
 
     var defaultGraph;
@@ -1086,13 +1115,13 @@ jsonld.merge = function(docs, ctx, options, callback) {
         // uniquely relabel blank nodes
         var doc = expanded[i];
         doc = jsonld.relabelBlankNodes(doc, {
-          namer: new UniqueNamer('_:b' + i + '-')
+          issuer: new IdentifierIssuer('_:b' + i + '-')
         });
 
         // add nodes to the shared node map graphs if merging nodes, to a
         // separate graph set if not
         var _graphs = (mergeNodes || i === 0) ? graphs : {'@default': {}};
-        _createNodeMap(doc, _graphs, '@default', namer);
+        _createNodeMap(doc, _graphs, '@default', issuer);
 
         if(_graphs !== graphs) {
           // merge document graphs but don't merge existing nodes
@@ -1152,12 +1181,25 @@ jsonld.merge = function(docs, ctx, options, callback) {
  *
  * @param input the JSON-LD input.
  * @param [options] the options to use:
- *          [namer] a jsonld.UniqueNamer to use.
+ *          [issuer] a jsonld.IdentifierIssuer to use to label blank nodes.
+ *          [namer] (deprecated).
  */
 jsonld.relabelBlankNodes = function(input, options) {
   options = options || {};
-  var namer = options.namer || new UniqueNamer('_:b');
-  return _labelBlankNodes(namer, input);
+  var issuer = options.namer || options.issuer || new IdentifierIssuer('_:b');
+  return _labelBlankNodes(issuer, input);
+};
+
+/**
+ * Prepends a base IRI to the given relative IRI.
+ *
+ * @param base the base IRI.
+ * @param iri the relative IRI.
+ *
+ * @return the absolute IRI.
+ */
+jsonld.prependBase = function(base, iri) {
+  return _prependBase(base, iri);
 };
 
 /**
@@ -1223,6 +1265,12 @@ jsonld.promises = function(options) {
     api = {};
   }
 
+  // The Web IDL test harness will check the number of parameters defined in
+  // the functions below. The number of parameters must exactly match the
+  // required (non-optional) parameters of the JsonLdProcessor interface as
+  // defined here:
+  // https://www.w3.org/TR/json-ld-api/#the-jsonldprocessor-interface
+
   api.expand = function(input) {
     if(arguments.length < 1) {
       throw new TypeError('Could not expand, too few arguments.');
@@ -1234,6 +1282,11 @@ jsonld.promises = function(options) {
       throw new TypeError('Could not compact, too few arguments.');
     }
     var compact = function(input, ctx, options, callback) {
+      if(typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+      options = options || {};
       // ensure only one value is returned in callback
       jsonld.compact(input, ctx, options, function(err, compacted) {
         callback(err, compacted);
@@ -1395,30 +1448,31 @@ if(_browser && typeof global.JsonLdProcessor === 'undefined') {
 /* Utility API */
 
 // define setImmediate and nextTick
-if(typeof process === 'undefined' || !process.nextTick) {
-  if(typeof setImmediate === 'function') {
-    jsonld.setImmediate = jsonld.nextTick = function(callback) {
-      return setImmediate(callback);
-    };
-  } else {
-    jsonld.setImmediate = function(callback) {
-      setTimeout(callback, 0);
-    };
-    jsonld.nextTick = jsonld.setImmediate;
-  }
-} else {
+//// nextTick implementation with browser-compatible fallback ////
+// from https://github.com/caolan/async/blob/master/lib/async.js
+
+// capture the global reference to guard against fakeTimer mocks
+var _setImmediate = typeof setImmediate === 'function' && setImmediate;
+
+var _delay = _setImmediate ? function(fn) {
+  // not a direct alias (for IE10 compatibility)
+  _setImmediate(fn);
+} : function(fn) {
+  setTimeout(fn, 0);
+};
+
+if(typeof process === 'object' && typeof process.nextTick === 'function') {
   jsonld.nextTick = process.nextTick;
-  if(typeof setImmediate === 'function') {
-    jsonld.setImmediate = setImmediate;
-  } else {
-    jsonld.setImmediate = jsonld.nextTick;
-  }
+} else {
+  jsonld.nextTick = _delay;
 }
+jsonld.setImmediate = _setImmediate ? _delay : jsonld.nextTick;
 
 /**
  * Parses a link header. The results will be key'd by the value of "rel".
  *
- * Link: <http://json-ld.org/contexts/person.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
+ * Link: <http://json-ld.org/contexts/person.jsonld>;
+ * rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"
  *
  * Parses as: {
  *   'http://www.w3.org/ns/json-ld#context': {
@@ -1458,6 +1512,64 @@ jsonld.parseLinkHeader = function(header) {
     }
   }
   return rval;
+};
+
+/**
+ * Creates a simple queue for requesting documents.
+ */
+jsonld.RequestQueue = function() {
+  this._requests = {};
+};
+jsonld.RequestQueue.prototype.wrapLoader = function(loader) {
+  this._loader = loader;
+  this._usePromise = (loader.length === 1);
+  return this.add.bind(this);
+};
+jsonld.RequestQueue.prototype.add = function(url, callback) {
+  var self = this;
+
+  // callback must be given if not using promises
+  if(!callback && !self._usePromise) {
+    throw new Error('callback must be specified.');
+  }
+
+  // Promise-based API
+  if(self._usePromise) {
+    return new jsonld.Promise(function(resolve, reject) {
+      var load = self._requests[url];
+      if(!load) {
+        // load URL then remove from queue
+        load = self._requests[url] = self._loader(url)
+          .then(function(remoteDoc) {
+            delete self._requests[url];
+            return remoteDoc;
+          }).catch(function(err) {
+            delete self._requests[url];
+            throw err;
+          });
+      }
+      // resolve/reject promise once URL has been loaded
+      load.then(function(remoteDoc) {
+        resolve(remoteDoc);
+      }).catch(function(err) {
+        reject(err);
+      });
+    });
+  }
+
+  // callback-based API
+  if(url in self._requests) {
+    self._requests[url].push(callback);
+  } else {
+    self._requests[url] = [callback];
+    self._loader(url, function(err, remoteDoc) {
+      var callbacks = self._requests[url];
+      delete self._requests[url];
+      for(var i = 0; i < callbacks.length; ++i) {
+        callbacks[i](err, remoteDoc);
+      }
+    });
+  }
 };
 
 /**
@@ -1535,6 +1647,42 @@ jsonld.cache = {
 };
 
 /**
+ * Accept header.
+ */
+var _defaults = {
+  headers: {
+    accept: 'application/ld+json, application/json'
+  }
+};
+
+/**
+ * Build an headers object from custom headers and assert `accept`
+ * header isn't overridden.
+ *
+ * @param {Object} optionsHeaders an object (map) of headers
+ *          with key as header name and value as header value.
+ * @return {Object} an object (map) of headers with a valid `accept` header.
+ */
+function buildHeaders(optionsHeaders) {
+  optionsHeaders = optionsHeaders || {};
+
+  var hasAccept = Object.keys(optionsHeaders).some(function(h) {
+    return h.toLowerCase() === 'accept';
+  });
+
+  if(hasAccept) {
+    throw new RangeError(
+      'Accept header may not be specified as an option; only "' +
+      _defaults.headers.accept + '" is supported.');
+  }
+
+  var headers = {'Accept': _defaults.headers.accept};
+  for(var k in optionsHeaders) {headers[k] = optionsHeaders[k];}
+
+  return headers;
+}
+
+/**
  * Document loaders.
  */
 jsonld.documentLoaders = {};
@@ -1545,6 +1693,8 @@ jsonld.documentLoaders = {};
  * @param $ the jquery instance to use.
  * @param options the options to use:
  *          secure: require all URLs to use HTTPS.
+ *          headers: an object (map) of headers which will be passed as request
+ *            headers for the requested document. Accept is not allowed.
  *          usePromise: true to use a promises API, false for a
  *            callback-continuation-style API; defaults to true if Promise
  *            is globally defined, false if not.
@@ -1553,7 +1703,20 @@ jsonld.documentLoaders = {};
  */
 jsonld.documentLoaders.jquery = function($, options) {
   options = options || {};
-  var loader = function(url, callback) {
+  var queue = new jsonld.RequestQueue();
+  var headers = buildHeaders(options.headers);
+
+  // use option or, by default, use Promise when its defined
+  var usePromise = ('usePromise' in options ?
+    options.usePromise : (typeof Promise !== 'undefined'));
+  if(usePromise) {
+    return queue.wrapLoader(function(url) {
+      return jsonld.promisify(loader, url);
+    });
+  }
+  return queue.wrapLoader(loader);
+
+  function loader(url, callback) {
     if(url.indexOf('http:') !== 0 && url.indexOf('https:') !== 0) {
       return callback(new JsonLdError(
         'URL could not be dereferenced; only "http" and "https" URLs are ' +
@@ -1571,12 +1734,9 @@ jsonld.documentLoaders.jquery = function($, options) {
     $.ajax({
       url: url,
       accepts: {
-        json: 'application/ld+json, application/json'
+        json: _defaults.headers.accept
       },
-      // ensure Accept header is very specific for JSON-LD/JSON
-      headers: {
-        'Accept': 'application/ld+json, application/json'
-      },
+      headers: headers,
       dataType: 'json',
       crossDomain: true,
       success: function(data, textStatus, jqXHR) {
@@ -1610,18 +1770,7 @@ jsonld.documentLoaders.jquery = function($, options) {
           {contextUrl: null, documentUrl: url, document: null});
       }
     });
-  };
-
-  var usePromise = (typeof Promise !== 'undefined');
-  if('usePromise' in options) {
-    usePromise = options.usePromise;
   }
-  if(usePromise) {
-    return function(url) {
-      return jsonld.promisify(loader, url);
-    };
-  }
-  return loader;
 };
 
 /**
@@ -1633,6 +1782,10 @@ jsonld.documentLoaders.jquery = function($, options) {
  *            false not to (default: true).
  *          maxRedirects: the maximum number of redirects to permit, none by
  *            default.
+ *          request: the object which will make the request, default is
+ *            provided by `https://www.npmjs.com/package/request`.
+ *          headers: an object (map) of headers which will be passed as request
+ *            headers for the requested document. Accept is not allowed.
  *          usePromise: true to use a promises API, false for a
  *            callback-continuation-style API; false by default.
  *
@@ -1640,11 +1793,25 @@ jsonld.documentLoaders.jquery = function($, options) {
  */
 jsonld.documentLoaders.node = function(options) {
   options = options || {};
+  var headers = buildHeaders(options.headers);
   var strictSSL = ('strictSSL' in options) ? options.strictSSL : true;
   var maxRedirects = ('maxRedirects' in options) ? options.maxRedirects : -1;
-  var request = require('request');
   var http = require('http');
-  var cache = new jsonld.DocumentCache();
+  var request = ('request' in options) ? options.request : http.request;
+  // TODO: disable cache until HTTP caching implemented
+  //var cache = new jsonld.DocumentCache();
+
+  var queue = new jsonld.RequestQueue();
+  if(options.usePromise) {
+    return queue.wrapLoader(function(url) {
+      return jsonld.promisify(loadDocument, url, []);
+    });
+  }
+
+  return queue.wrapLoader(function(url, callback) {
+    loadDocument(url, [], callback);
+  });
+
   function loadDocument(url, redirects, callback) {
     if(url.indexOf('http:') !== 0 && url.indexOf('https:') !== 0) {
       return callback(new JsonLdError(
@@ -1660,15 +1827,15 @@ jsonld.documentLoaders.node = function(options) {
         'jsonld.InvalidUrl', {code: 'loading document failed', url: url}),
         {contextUrl: null, documentUrl: url, document: null});
     }
-    var doc = cache.get(url);
+    // TODO: disable cache until HTTP caching implemented
+    var doc = null;//cache.get(url);
     if(doc !== null) {
       return callback(null, doc);
     }
+
     request({
       url: url,
-      headers: {
-        'Accept': 'application/ld+json, application/json'
-      },
+      headers: headers,
       strictSSL: strictSSL,
       followRedirect: false
     }, handleResponse);
@@ -1740,24 +1907,15 @@ jsonld.documentLoaders.node = function(options) {
       }
       // cache for each redirected URL
       redirects.push(url);
-      for(var i = 0; i < redirects.length; ++i) {
+      // TODO: disable cache until HTTP caching implemented
+      /*for(var i = 0; i < redirects.length; ++i) {
         cache.set(
           redirects[i],
           {contextUrl: null, documentUrl: redirects[i], document: body});
-      }
+      }*/
       callback(err, doc);
     }
   }
-
-  var loader = function(url, callback) {
-    loadDocument(url, [], callback);
-  };
-  if(options.usePromise) {
-    return function(url) {
-      return jsonld.promisify(loader, url);
-    };
-  }
-  return loader;
 };
 
 /**
@@ -1765,6 +1923,8 @@ jsonld.documentLoaders.node = function(options) {
  *
  * @param options the options to use:
  *          secure: require all URLs to use HTTPS.
+ *          headers: an object (map) of headers which will be passed as request
+ *            headers for the requested document. Accept is not allowed.
  *          usePromise: true to use a promises API, false for a
  *            callback-continuation-style API; defaults to true if Promise
  *            is globally defined, false if not.
@@ -1773,9 +1933,22 @@ jsonld.documentLoaders.node = function(options) {
  * @return the XMLHttpRequest document loader.
  */
 jsonld.documentLoaders.xhr = function(options) {
-  var rlink = /(^|(\r\n))link:/i;
   options = options || {};
-  var loader = function(url, callback) {
+  var rlink = /(^|(\r\n))link:/i;
+  var queue = new jsonld.RequestQueue();
+  var headers = buildHeaders(options.headers);
+
+  // use option or, by default, use Promise when its defined
+  var usePromise = ('usePromise' in options ?
+    options.usePromise : (typeof Promise !== 'undefined'));
+  if(usePromise) {
+    return queue.wrapLoader(function(url) {
+      return jsonld.promisify(loader, url);
+    });
+  }
+  return queue.wrapLoader(loader);
+
+  function loader(url, callback) {
     if(url.indexOf('http:') !== 0 && url.indexOf('https:') !== 0) {
       return callback(new JsonLdError(
         'URL could not be dereferenced; only "http" and "https" URLs are ' +
@@ -1792,7 +1965,7 @@ jsonld.documentLoaders.xhr = function(options) {
     }
     var xhr = options.xhr || XMLHttpRequest;
     var req = new xhr();
-    req.onload = function(e) {
+    req.onload = function() {
       if(req.status >= 400) {
         return callback(new JsonLdError(
           'URL could not be dereferenced: ' + req.statusText,
@@ -1836,20 +2009,13 @@ jsonld.documentLoaders.xhr = function(options) {
         {contextUrl: null, documentUrl: url, document: null});
     };
     req.open('GET', url, true);
-    req.setRequestHeader('Accept', 'application/ld+json, application/json');
-    req.send();
-  };
 
-  var usePromise = (typeof Promise !== 'undefined');
-  if('usePromise' in options) {
-    usePromise = options.usePromise;
+    for(var k in headers) {
+      req.setRequestHeader(k, headers[k]);
+    }
+
+    req.send();
   }
-  if(usePromise) {
-    return function(url) {
-      return jsonld.promisify(loader, url);
-    };
-  }
-  return loader;
 };
 
 /**
@@ -2215,7 +2381,7 @@ if(_nodejs) {
       DOCUMENT_NODE: 9,
       DOCUMENT_TYPE_NODE: 10,
       DOCUMENT_FRAGMENT_NODE: 11,
-      NOTATION_NODE:12
+      NOTATION_NODE: 12
     };
   }
 }
@@ -2680,6 +2846,10 @@ Processor.prototype.expand = function(
 
     // @language must be a string
     if(expandedProperty === '@language') {
+      if(value === null) {
+        // drop null @language values, they expand as if they didn't exist
+        continue;
+      }
       if(!_isString(value)) {
         throw new JsonLdError(
           'Invalid JSON-LD syntax; "@language" value must be a string.',
@@ -2926,7 +3096,8 @@ Processor.prototype.expand = function(
  *
  * @param input the expanded JSON-LD to create a node map of.
  * @param [options] the options to use:
- *          [namer] the UniqueNamer to use.
+ *          [issuer] a jsonld.IdentifierIssuer to use to label blank nodes.
+ *          [namer] (deprecated).
  *
  * @return the node map.
  */
@@ -2934,9 +3105,9 @@ Processor.prototype.createNodeMap = function(input, options) {
   options = options || {};
 
   // produce a map of all subjects and name each bnode
-  var namer = options.namer || new UniqueNamer('_:b');
+  var issuer = options.namer || options.issuer || new IdentifierIssuer('_:b');
   var graphs = {'@default': {}};
-  _createNodeMap(input, graphs, '@default', namer);
+  _createNodeMap(input, graphs, '@default', issuer);
 
   // add all non-default graphs to default graph
   return _mergeNodeMaps(graphs);
@@ -2985,8 +3156,8 @@ Processor.prototype.frame = function(input, frame, options) {
 
   // produce a map of all graphs and name each bnode
   // FIXME: currently uses subjects from @merged graph only
-  var namer = new UniqueNamer('_:b');
-  _createNodeMap(input, state.graphs, '@merged', namer);
+  var issuer = new IdentifierIssuer('_:b');
+  _createNodeMap(input, state.graphs, '@merged', issuer);
   state.subjects = state.graphs['@merged'];
 
   // frame the subjects
@@ -3003,195 +3174,14 @@ Processor.prototype.frame = function(input, frame, options) {
  * @param callback(err, normalized) called once the operation completes.
  */
 Processor.prototype.normalize = function(dataset, options, callback) {
-  // create quads and map bnodes to their associated quads
-  var quads = [];
-  var bnodes = {};
-  for(var graphName in dataset) {
-    var triples = dataset[graphName];
-    if(graphName === '@default') {
-      graphName = null;
-    }
-    for(var ti = 0; ti < triples.length; ++ti) {
-      var quad = triples[ti];
-      if(graphName !== null) {
-        if(graphName.indexOf('_:') === 0) {
-          quad.name = {type: 'blank node', value: graphName};
-        } else {
-          quad.name = {type: 'IRI', value: graphName};
-        }
-      }
-      quads.push(quad);
-
-      var attrs = ['subject', 'object', 'name'];
-      for(var ai = 0; ai < attrs.length; ++ai) {
-        var attr = attrs[ai];
-        if(quad[attr] && quad[attr].type === 'blank node') {
-          var id = quad[attr].value;
-          if(id in bnodes) {
-            bnodes[id].quads.push(quad);
-          } else {
-            bnodes[id] = {quads: [quad]};
-          }
-        }
-      }
-    }
+  if(options.algorithm === 'URDNA2015') {
+    return new URDNA2015(options).main(dataset, callback);
   }
-
-  // mapping complete, start canonical naming
-  var namer = new UniqueNamer('_:c14n');
-  return hashBlankNodes(Object.keys(bnodes));
-
-  // generates unique and duplicate hashes for bnodes
-  function hashBlankNodes(unnamed) {
-    var nextUnnamed = [];
-    var duplicates = {};
-    var unique = {};
-
-    // hash quads for each unnamed bnode
-    jsonld.setImmediate(function() {hashUnnamed(0);});
-    function hashUnnamed(i) {
-      if(i === unnamed.length) {
-        // done, name blank nodes
-        return nameBlankNodes(unique, duplicates, nextUnnamed);
-      }
-
-      // hash unnamed bnode
-      var bnode = unnamed[i];
-      var hash = _hashQuads(bnode, bnodes);
-
-      // store hash as unique or a duplicate
-      if(hash in duplicates) {
-        duplicates[hash].push(bnode);
-        nextUnnamed.push(bnode);
-      } else if(hash in unique) {
-        duplicates[hash] = [unique[hash], bnode];
-        nextUnnamed.push(unique[hash]);
-        nextUnnamed.push(bnode);
-        delete unique[hash];
-      } else {
-        unique[hash] = bnode;
-      }
-
-      // hash next unnamed bnode
-      jsonld.setImmediate(function() {hashUnnamed(i + 1);});
-    }
+  if(options.algorithm === 'URGNA2012') {
+    return new URGNA2012(options).main(dataset, callback);
   }
-
-  // names unique hash bnodes
-  function nameBlankNodes(unique, duplicates, unnamed) {
-    // name unique bnodes in sorted hash order
-    var named = false;
-    var hashes = Object.keys(unique).sort();
-    for(var i = 0; i < hashes.length; ++i) {
-      var bnode = unique[hashes[i]];
-      namer.getName(bnode);
-      named = true;
-    }
-
-    if(named) {
-      // continue to hash bnodes if a bnode was assigned a name
-      hashBlankNodes(unnamed);
-    } else {
-      // name the duplicate hash bnodes
-      nameDuplicates(duplicates);
-    }
-  }
-
-  // names duplicate hash bnodes
-  function nameDuplicates(duplicates) {
-    // enumerate duplicate hash groups in sorted order
-    var hashes = Object.keys(duplicates).sort();
-
-    // process each group
-    processGroup(0);
-    function processGroup(i) {
-      if(i === hashes.length) {
-        // done, create JSON-LD array
-        return createArray();
-      }
-
-      // name each group member
-      var group = duplicates[hashes[i]];
-      var results = [];
-      nameGroupMember(group, 0);
-      function nameGroupMember(group, n) {
-        if(n === group.length) {
-          // name bnodes in hash order
-          results.sort(function(a, b) {
-            a = a.hash;
-            b = b.hash;
-            return (a < b) ? -1 : ((a > b) ? 1 : 0);
-          });
-          for(var r in results) {
-            // name all bnodes in path namer in key-entry order
-            // Note: key-order is preserved in javascript
-            for(var key in results[r].pathNamer.existing) {
-              namer.getName(key);
-            }
-          }
-          return processGroup(i + 1);
-        }
-
-        // skip already-named bnodes
-        var bnode = group[n];
-        if(namer.isNamed(bnode)) {
-          return nameGroupMember(group, n + 1);
-        }
-
-        // hash bnode paths
-        var pathNamer = new UniqueNamer('_:b');
-        pathNamer.getName(bnode);
-        _hashPaths(bnode, bnodes, namer, pathNamer,
-          function(err, result) {
-            if(err) {
-              return callback(err);
-            }
-            results.push(result);
-            nameGroupMember(group, n + 1);
-          });
-      }
-    }
-  }
-
-  // creates the sorted array of RDF quads
-  function createArray() {
-    var normalized = [];
-
-    /* Note: At this point all bnodes in the set of RDF quads have been
-     assigned canonical names, which have been stored in the 'namer' object.
-     Here each quad is updated by assigning each of its bnodes its new name
-     via the 'namer' object. */
-
-    // update bnode names in each quad and serialize
-    for(var i = 0; i < quads.length; ++i) {
-      var quad = quads[i];
-      var attrs = ['subject', 'object', 'name'];
-      for(var ai = 0; ai < attrs.length; ++ai) {
-        var attr = attrs[ai];
-        if(quad[attr] && quad[attr].type === 'blank node' &&
-          quad[attr].value.indexOf('_:c14n') !== 0) {
-          quad[attr].value = namer.getName(quad[attr].value);
-        }
-      }
-      normalized.push(_toNQuad(quad, quad.name ? quad.name.value : null));
-    }
-
-    // sort normalized output
-    normalized.sort();
-
-    // handle output format
-    if(options.format) {
-      if(options.format === 'application/nquads') {
-        return callback(null, normalized.join(''));
-      }
-      return callback(new JsonLdError(
-        'Unknown output format.',
-        'jsonld.UnknownFormat', {format: options.format}));
-    }
-
-    // output RDF dataset
-    callback(null, _parseNQuads(normalized.join('')));
-  }
+  callback(new Error(
+    'Invalid RDF Dataset Normalization algorithm: ' + options.algorithm));
 };
 
 /**
@@ -3380,9 +3370,9 @@ Processor.prototype.fromRDF = function(dataset, options, callback) {
  */
 Processor.prototype.toRDF = function(input, options) {
   // create node map for default graph (and any named graphs)
-  var namer = new UniqueNamer('_:b');
+  var issuer = new IdentifierIssuer('_:b');
   var nodeMap = {'@default': {}};
-  _createNodeMap(input, nodeMap, '@default', namer);
+  _createNodeMap(input, nodeMap, '@default', issuer);
 
   var dataset = {};
   var graphNames = Object.keys(nodeMap).sort();
@@ -3390,7 +3380,7 @@ Processor.prototype.toRDF = function(input, options) {
     var graphName = graphNames[i];
     // skip relative IRIs
     if(graphName === '@default' || _isAbsoluteIri(graphName)) {
-      dataset[graphName] = _graphToRDF(nodeMap[graphName], namer, options);
+      dataset[graphName] = _graphToRDF(nodeMap[graphName], issuer, options);
     }
   }
   return dataset;
@@ -3554,6 +3544,10 @@ function _expandLanguageMap(languageMap) {
     }
     for(var vi = 0; vi < val.length; ++vi) {
       var item = val[vi];
+      if(item === null) {
+        // null values are allowed (8.5) but ignored (3.1)
+        continue;
+      }
       if(!_isString(item)) {
         throw new JsonLdError(
           'Invalid JSON-LD syntax; language map values must be strings.',
@@ -3570,24 +3564,24 @@ function _expandLanguageMap(languageMap) {
 }
 
 /**
- * Labels the blank nodes in the given value using the given UniqueNamer.
+ * Labels the blank nodes in the given value using the given IdentifierIssuer.
  *
- * @param namer the UniqueNamer to use.
+ * @param issuer the IdentifierIssuer to use.
  * @param element the element with blank nodes to rename.
  *
  * @return the element.
  */
-function _labelBlankNodes(namer, element) {
+function _labelBlankNodes(issuer, element) {
   if(_isArray(element)) {
     for(var i = 0; i < element.length; ++i) {
-      element[i] = _labelBlankNodes(namer, element[i]);
+      element[i] = _labelBlankNodes(issuer, element[i]);
     }
   } else if(_isList(element)) {
-    element['@list'] = _labelBlankNodes(namer, element['@list']);
+    element['@list'] = _labelBlankNodes(issuer, element['@list']);
   } else if(_isObject(element)) {
-    // rename blank node
+    // relabel blank node
     if(_isBlankNode(element)) {
-      element['@id'] = namer.getName(element['@id']);
+      element['@id'] = issuer.getId(element['@id']);
     }
 
     // recursively apply to all keys
@@ -3595,7 +3589,7 @@ function _labelBlankNodes(namer, element) {
     for(var ki = 0; ki < keys.length; ++ki) {
       var key = keys[ki];
       if(key !== '@id') {
-        element[key] = _labelBlankNodes(namer, element[key]);
+        element[key] = _labelBlankNodes(issuer, element[key]);
       }
     }
   }
@@ -3670,12 +3664,12 @@ function _expandValue(activeCtx, activeProperty, value) {
  * Creates an array of RDF triples for the given graph.
  *
  * @param graph the graph to create RDF triples for.
- * @param namer a UniqueNamer for assigning blank node names.
+ * @param issuer a IdentifierIssuer for assigning blank node names.
  * @param options the RDF serialization options.
  *
  * @return the array of RDF triples for the given graph.
  */
-function _graphToRDF(graph, namer, options) {
+function _graphToRDF(graph, issuer, options) {
   var rval = [];
 
   var ids = Object.keys(graph).sort();
@@ -3722,7 +3716,7 @@ function _graphToRDF(graph, namer, options) {
 
         // convert @list to triples
         if(_isList(item)) {
-          _listToRDF(item['@list'], namer, subject, predicate, rval);
+          _listToRDF(item['@list'], issuer, subject, predicate, rval);
         } else {
           // convert value or node object to triple
           var object = _objectToRDF(item);
@@ -3743,12 +3737,12 @@ function _graphToRDF(graph, namer, options) {
  * (an RDF collection).
  *
  * @param list the @list value.
- * @param namer a UniqueNamer for assigning blank node names.
+ * @param issuer a IdentifierIssuer for assigning blank node names.
  * @param subject the subject for the head of the list.
  * @param predicate the predicate for the head of the list.
  * @param triples the array of triples to append to.
  */
-function _listToRDF(list, namer, subject, predicate, triples) {
+function _listToRDF(list, issuer, subject, predicate, triples) {
   var first = {type: 'IRI', value: RDF_FIRST};
   var rest = {type: 'IRI', value: RDF_REST};
   var nil = {type: 'IRI', value: RDF_NIL};
@@ -3756,7 +3750,7 @@ function _listToRDF(list, namer, subject, predicate, triples) {
   for(var i = 0; i < list.length; ++i) {
     var item = list[i];
 
-    var blankNode = {type: 'blank node', value: namer.getName()};
+    var blankNode = {type: 'blank node', value: issuer.getId()};
     triples.push({subject: subject, predicate: predicate, object: blankNode});
 
     subject = blankNode;
@@ -3909,215 +3903,801 @@ function _compareRDFTriples(t1, t2) {
   return true;
 }
 
-/**
- * Hashes all of the quads about a blank node.
- *
- * @param id the ID of the bnode to hash quads for.
- * @param bnodes the mapping of bnodes to quads.
- *
- * @return the new hash.
- */
-function _hashQuads(id, bnodes) {
-  // return cached hash
-  if('hash' in bnodes[id]) {
-    return bnodes[id].hash;
+/////////////////////////////// DEFINE URDNA2015 //////////////////////////////
+
+var URDNA2015 = (function() {
+
+var POSITIONS = {'subject': 's', 'object': 'o', 'name': 'g'};
+
+var Normalize = function(options) {
+  options = options || {};
+  this.name = 'URDNA2015';
+  this.options = options;
+  this.blankNodeInfo = {};
+  this.hashToBlankNodes = {};
+  this.canonicalIssuer = new IdentifierIssuer('_:c14n');
+  this.quads = [];
+  this.schedule = {};
+  if('maxCallStackDepth' in options) {
+    this.schedule.MAX_DEPTH = options.maxCallStackDepth;
+  } else {
+    this.schedule.MAX_DEPTH = 500;
+  }
+  if('maxTotalCallStackDepth' in options) {
+    this.schedule.MAX_TOTAL_DEPTH = options.maxCallStackDepth;
+  } else {
+    this.schedule.MAX_TOTAL_DEPTH = 0xFFFFFFFF;
+  }
+  this.schedule.depth = 0;
+  this.schedule.totalDepth = 0;
+  if('timeSlice' in options) {
+    this.schedule.timeSlice = options.timeSlice;
+  } else {
+    // milliseconds
+    this.schedule.timeSlice = 10;
+  }
+};
+
+// do some work in a time slice, but in serial
+Normalize.prototype.doWork = function(fn, callback) {
+  var schedule = this.schedule;
+
+  if(schedule.totalDepth >= schedule.MAX_TOTAL_DEPTH) {
+    return callback(new Error(
+      'Maximum total call stack depth exceeded; normalization aborting.'));
   }
 
-  // serialize all of bnode's quads
-  var quads = bnodes[id].quads;
-  var nquads = [];
-  for(var i = 0; i < quads.length; ++i) {
-    nquads.push(_toNQuad(
-      quads[i], quads[i].name ? quads[i].name.value : null, id));
-  }
-  // sort serialized quads
-  nquads.sort();
-  // return hashed quads
-  var hash = bnodes[id].hash = sha1.hash(nquads);
-  return hash;
-}
-
-/**
- * Produces a hash for the paths of adjacent bnodes for a bnode,
- * incorporating all information about its subgraph of bnodes. This
- * method will recursively pick adjacent bnode permutations that produce the
- * lexicographically-least 'path' serializations.
- *
- * @param id the ID of the bnode to hash paths for.
- * @param bnodes the map of bnode quads.
- * @param namer the canonical bnode namer.
- * @param pathNamer the namer used to assign names to adjacent bnodes.
- * @param callback(err, result) called once the operation completes.
- */
-function _hashPaths(id, bnodes, namer, pathNamer, callback) {
-  // create SHA-1 digest
-  var md = sha1.create();
-
-  // group adjacent bnodes by hash, keep properties and references separate
-  var groups = {};
-  var groupHashes;
-  var quads = bnodes[id].quads;
-  jsonld.setImmediate(function() {groupNodes(0);});
-  function groupNodes(i) {
-    if(i === quads.length) {
-      // done, hash groups
-      groupHashes = Object.keys(groups).sort();
-      return hashGroup(0);
+  (function work() {
+    if(schedule.depth === schedule.MAX_DEPTH) {
+      // stack too deep, run on next tick
+      schedule.depth = 0;
+      schedule.running = false;
+      return jsonld.nextTick(work);
     }
 
-    // get adjacent bnode
-    var quad = quads[i];
-    var bnode = _getAdjacentBlankNodeName(quad.subject, id);
-    var direction = null;
-    if(bnode !== null) {
-      // normal property
-      direction = 'p';
-    } else {
-      bnode = _getAdjacentBlankNodeName(quad.object, id);
-      if(bnode !== null) {
-        // reverse property
-        direction = 'r';
-      }
+    // if not yet running, force run
+    var now = new Date().getTime();
+    if(!schedule.running) {
+      schedule.start = new Date().getTime();
+      schedule.deadline = schedule.start + schedule.timeSlice;
     }
 
-    if(bnode !== null) {
-      // get bnode name (try canonical, path, then hash)
-      var name;
-      if(namer.isNamed(bnode)) {
-        name = namer.getName(bnode);
-      } else if(pathNamer.isNamed(bnode)) {
-        name = pathNamer.getName(bnode);
-      } else {
-        name = _hashQuads(bnode, bnodes);
-      }
-
-      // hash direction, property, and bnode name/hash
-      var md = sha1.create();
-      md.update(direction);
-      md.update(quad.predicate.value);
-      md.update(name);
-      var groupHash = md.digest();
-
-      // add bnode to hash group
-      if(groupHash in groups) {
-        groups[groupHash].push(bnode);
-      } else {
-        groups[groupHash] = [bnode];
-      }
+    // TODO: should also include an estimate of expectedWorkTime
+    if(now < schedule.deadline) {
+      schedule.running = true;
+      schedule.depth++;
+      schedule.totalDepth++;
+      return fn(function(err, result) {
+        schedule.depth--;
+        schedule.totalDepth--;
+        callback(err, result);
+      });
     }
 
-    jsonld.setImmediate(function() {groupNodes(i + 1);});
+    // not enough time left in this slice, run after letting browser
+    // do some other things
+    schedule.depth = 0;
+    schedule.running = false;
+    jsonld.setImmediate(work);
+  })();
+};
+
+// asynchronously loop
+Normalize.prototype.forEach = function(iterable, fn, callback) {
+  var self = this;
+  var iterator;
+  var idx = 0;
+  var length;
+  if(_isArray(iterable)) {
+    length = iterable.length;
+    iterator = function() {
+      if(idx === length) {
+        return false;
+      }
+      iterator.value = iterable[idx++];
+      iterator.key = idx;
+      return true;
+    };
+  } else {
+    var keys = Object.keys(iterable);
+    length = keys.length;
+    iterator = function() {
+      if(idx === length) {
+        return false;
+      }
+      iterator.key = keys[idx++];
+      iterator.value = iterable[iterator.key];
+      return true;
+    };
   }
 
-  // hashes a group of adjacent bnodes
-  function hashGroup(i) {
-    if(i === groupHashes.length) {
-      // done, return SHA-1 digest and path namer
-      return callback(null, {hash: md.digest(), pathNamer: pathNamer});
+  (function iterate(err, result) {
+    if(err) {
+      return callback(err);
     }
+    if(iterator()) {
+      return self.doWork(function() {
+        fn(iterator.value, iterator.key, iterate);
+      });
+    }
+    callback();
+  })();
+};
 
-    // digest group hash
-    var groupHash = groupHashes[i];
-    md.update(groupHash);
+// asynchronous waterfall
+Normalize.prototype.waterfall = function(fns, callback) {
+  var self = this;
+  self.forEach(fns, function(fn, idx, callback) {
+    self.doWork(fn, callback);
+  }, callback);
+};
 
-    // choose a path and namer from the permutations
-    var chosenPath = null;
-    var chosenNamer = null;
-    var permutator = new Permutator(groups[groupHash]);
-    jsonld.setImmediate(function() {permutate();});
-    function permutate() {
-      var permutation = permutator.next();
-      var pathNamerCopy = pathNamer.clone();
+// asynchronous while
+Normalize.prototype.whilst = function(condition, fn, callback) {
+  var self = this;
+  (function loop(err) {
+    if(err) {
+      return callback(err);
+    }
+    if(!condition()) {
+      return callback();
+    }
+    self.doWork(fn, loop);
+  })();
+};
 
-      // build adjacent path
-      var path = '';
-      var recurse = [];
-      for(var n in permutation) {
-        var bnode = permutation[n];
+// 4.4) Normalization Algorithm
+Normalize.prototype.main = function(dataset, callback) {
+  var self = this;
+  self.schedule.start = new Date().getTime();
+  var result;
 
-        // use canonical name if available
-        if(namer.isNamed(bnode)) {
-          path += namer.getName(bnode);
-        } else {
-          // recurse if bnode isn't named in the path yet
-          if(!pathNamerCopy.isNamed(bnode)) {
-            recurse.push(bnode);
+  // handle invalid output format
+  if(self.options.format) {
+    if(self.options.format !== 'application/nquads') {
+      return callback(new JsonLdError(
+        'Unknown output format.',
+        'jsonld.UnknownFormat', {format: self.options.format}));
+    }
+  }
+
+  // 1) Create the normalization state.
+
+  // Note: Optimize by generating non-normalized blank node map concurrently.
+  var nonNormalized = {};
+
+  self.waterfall([
+    function(callback) {
+      // 2) For every quad in input dataset:
+      self.forEach(dataset, function(triples, graphName, callback) {
+        if(graphName === '@default') {
+          graphName = null;
+        }
+        self.forEach(triples, function(quad, idx, callback) {
+          if(graphName !== null) {
+            if(graphName.indexOf('_:') === 0) {
+              quad.name = {type: 'blank node', value: graphName};
+            } else {
+              quad.name = {type: 'IRI', value: graphName};
+            }
           }
-          path += pathNamerCopy.getName(bnode);
-        }
+          self.quads.push(quad);
 
-        // skip permutation if path is already >= chosen path
-        if(chosenPath !== null && path.length >= chosenPath.length &&
-          path > chosenPath) {
-          return nextPermutation(true);
-        }
-      }
-
-      // does the next recursion
-      nextRecursion(0);
-      function nextRecursion(n) {
-        if(n === recurse.length) {
-          // done, do next permutation
-          return nextPermutation(false);
-        }
-
-        // do recursion
-        var bnode = recurse[n];
-        _hashPaths(bnode, bnodes, namer, pathNamerCopy,
-          function(err, result) {
-            if(err) {
-              return callback(err);
+          // 2.1) For each blank node that occurs in the quad, add a reference
+          // to the quad using the blank node identifier in the blank node to
+          // quads map, creating a new entry if necessary.
+          self.forEachComponent(quad, function(component) {
+            if(component.type !== 'blank node') {
+              return;
             }
-            path += pathNamerCopy.getName(bnode) + '<' + result.hash + '>';
-            pathNamerCopy = result.pathNamer;
-
-            // skip permutation if path is already >= chosen path
-            if(chosenPath !== null && path.length >= chosenPath.length &&
-              path > chosenPath) {
-              return nextPermutation(true);
+            var id = component.value;
+            if(id in self.blankNodeInfo) {
+              self.blankNodeInfo[id].quads.push(quad);
+            } else {
+              nonNormalized[id] = true;
+              self.blankNodeInfo[id] = {quads: [quad]};
             }
-
-            // do next recursion
-            nextRecursion(n + 1);
           });
-      }
+          callback();
+        }, callback);
+      }, callback);
+    },
+    function(callback) {
+      // 3) Create a list of non-normalized blank node identifiers
+      // non-normalized identifiers and populate it using the keys from the
+      // blank node to quads map.
+      // Note: We use a map here and it was generated during step 2.
 
-      // stores the results of this permutation and runs the next
-      function nextPermutation(skipped) {
-        if(!skipped && (chosenPath === null || path < chosenPath)) {
-          chosenPath = path;
-          chosenNamer = pathNamerCopy;
+      // 4) Initialize simple, a boolean flag, to true.
+      var simple = true;
+
+      // 5) While simple is true, issue canonical identifiers for blank nodes:
+      self.whilst(function() {return simple;}, function(callback) {
+        // 5.1) Set simple to false.
+        simple = false;
+
+        // 5.2) Clear hash to blank nodes map.
+        self.hashToBlankNodes = {};
+
+        self.waterfall([
+          function(callback) {
+            // 5.3) For each blank node identifier identifier in non-normalized
+            // identifiers:
+            self.forEach(nonNormalized, function(value, id, callback) {
+              // 5.3.1) Create a hash, hash, according to the Hash First Degree
+              // Quads algorithm.
+              self.hashFirstDegreeQuads(id, function(err, hash) {
+                if(err) {
+                  return callback(err);
+                }
+                // 5.3.2) Add hash and identifier to hash to blank nodes map,
+                // creating a new entry if necessary.
+                if(hash in self.hashToBlankNodes) {
+                  self.hashToBlankNodes[hash].push(id);
+                } else {
+                  self.hashToBlankNodes[hash] = [id];
+                }
+                callback();
+              });
+            }, callback);
+          },
+          function(callback) {
+            // 5.4) For each hash to identifier list mapping in hash to blank
+            // nodes map, lexicographically-sorted by hash:
+            var hashes = Object.keys(self.hashToBlankNodes).sort();
+            self.forEach(hashes, function(hash, i, callback) {
+              // 5.4.1) If the length of identifier list is greater than 1,
+              // continue to the next mapping.
+              var idList = self.hashToBlankNodes[hash];
+              if(idList.length > 1) {
+                return callback();
+              }
+
+              // 5.4.2) Use the Issue Identifier algorithm, passing canonical
+              // issuer and the single blank node identifier in identifier
+              // list, identifier, to issue a canonical replacement identifier
+              // for identifier.
+              // TODO: consider changing `getId` to `issue`
+              var id = idList[0];
+              self.canonicalIssuer.getId(id);
+
+              // 5.4.3) Remove identifier from non-normalized identifiers.
+              delete nonNormalized[id];
+
+              // 5.4.4) Remove hash from the hash to blank nodes map.
+              delete self.hashToBlankNodes[hash];
+
+              // 5.4.5) Set simple to true.
+              simple = true;
+              callback();
+            }, callback);
+          }
+        ], callback);
+      }, callback);
+    },
+    function(callback) {
+      // 6) For each hash to identifier list mapping in hash to blank nodes map,
+      // lexicographically-sorted by hash:
+      var hashes = Object.keys(self.hashToBlankNodes).sort();
+      self.forEach(hashes, function(hash, idx, callback) {
+        // 6.1) Create hash path list where each item will be a result of
+        // running the Hash N-Degree Quads algorithm.
+        var hashPathList = [];
+
+        // 6.2) For each blank node identifier identifier in identifier list:
+        var idList = self.hashToBlankNodes[hash];
+        self.waterfall([
+          function(callback) {
+            self.forEach(idList, function(id, idx, callback) {
+              // 6.2.1) If a canonical identifier has already been issued for
+              // identifier, continue to the next identifier.
+              if(self.canonicalIssuer.hasId(id)) {
+                return callback();
+              }
+
+              // 6.2.2) Create temporary issuer, an identifier issuer
+              // initialized with the prefix _:b.
+              var issuer = new IdentifierIssuer('_:b');
+
+              // 6.2.3) Use the Issue Identifier algorithm, passing temporary
+              // issuer and identifier, to issue a new temporary blank node
+              // identifier for identifier.
+              issuer.getId(id);
+
+              // 6.2.4) Run the Hash N-Degree Quads algorithm, passing
+              // temporary issuer, and append the result to the hash path list.
+              self.hashNDegreeQuads(id, issuer, function(err, result) {
+                if(err) {
+                  return callback(err);
+                }
+                hashPathList.push(result);
+                callback();
+              });
+            }, callback);
+          },
+          function(callback) {
+            // 6.3) For each result in the hash path list,
+            // lexicographically-sorted by the hash in result:
+            hashPathList.sort(function(a, b) {
+              return (a.hash < b.hash) ? -1 : ((a.hash > b.hash) ? 1 : 0);
+            });
+            self.forEach(hashPathList, function(result, idx, callback) {
+              // 6.3.1) For each blank node identifier, existing identifier,
+              // that was issued a temporary identifier by identifier issuer
+              // in result, issue a canonical identifier, in the same order,
+              // using the Issue Identifier algorithm, passing canonical
+              // issuer and existing identifier.
+              for(var existing in result.issuer.existing) {
+                self.canonicalIssuer.getId(existing);
+              }
+              callback();
+            }, callback);
+          }
+        ], callback);
+      }, callback);
+    }, function(callback) {
+      /* Note: At this point all blank nodes in the set of RDF quads have been
+      assigned canonical identifiers, which have been stored in the canonical
+      issuer. Here each quad is updated by assigning each of its blank nodes
+      its new identifier. */
+
+      // 7) For each quad, quad, in input dataset:
+      var normalized = [];
+      self.waterfall([
+        function(callback) {
+          self.forEach(self.quads, function(quad, idx, callback) {
+            // 7.1) Create a copy, quad copy, of quad and replace any existing
+            // blank node identifiers using the canonical identifiers
+            // previously issued by canonical issuer.
+            // Note: We optimize away the copy here.
+            self.forEachComponent(quad, function(component) {
+              if(component.type === 'blank node' &&
+                component.value.indexOf(self.canonicalIssuer.prefix) !== 0) {
+                component.value = self.canonicalIssuer.getId(component.value);
+              }
+            });
+            // 7.2) Add quad copy to the normalized dataset.
+            normalized.push(_toNQuad(quad));
+            callback();
+          }, callback);
+        },
+        function(callback) {
+          // sort normalized output
+          normalized.sort();
+
+          // 8) Return the normalized dataset.
+          if(self.options.format === 'application/nquads') {
+            result = normalized.join('');
+            return callback();
+          }
+
+          result = _parseNQuads(normalized.join(''));
+          callback();
         }
-
-        // do next permutation
-        if(permutator.hasNext()) {
-          jsonld.setImmediate(function() {permutate();});
-        } else {
-          // digest chosen path and update namer
-          md.update(chosenPath);
-          pathNamer = chosenNamer;
-
-          // hash the next group
-          hashGroup(i + 1);
-        }
-      }
+      ], callback);
     }
-  }
-}
+  ], function(err) {
+    callback(err, result);
+  });
+};
 
-/**
- * A helper function that gets the blank node name from an RDF quad node
- * (subject or object). If the node is a blank node and its value
- * does not match the given blank node ID, it will be returned.
- *
- * @param node the RDF quad node.
- * @param id the ID of the blank node to look next to.
- *
- * @return the adjacent blank node name or null if none was found.
- */
-function _getAdjacentBlankNodeName(node, id) {
-  return (node.type === 'blank node' && node.value !== id ? node.value : null);
-}
+// 4.6) Hash First Degree Quads
+Normalize.prototype.hashFirstDegreeQuads = function(id, callback) {
+  var self = this;
+
+  // return cached hash
+  var info = self.blankNodeInfo[id];
+  if('hash' in info) {
+    return callback(null, info.hash);
+  }
+
+  // 1) Initialize nquads to an empty list. It will be used to store quads in
+  // N-Quads format.
+  var nquads = [];
+
+  // 2) Get the list of quads quads associated with the reference blank node
+  // identifier in the blank node to quads map.
+  var quads = info.quads;
+
+  // 3) For each quad quad in quads:
+  self.forEach(quads, function(quad, idx, callback) {
+    // 3.1) Serialize the quad in N-Quads format with the following special
+    // rule:
+
+    // 3.1.1) If any component in quad is an blank node, then serialize it
+    // using a special identifier as follows:
+    var copy = {predicate: quad.predicate};
+    self.forEachComponent(quad, function(component, key) {
+      // 3.1.2) If the blank node's existing blank node identifier matches the
+      // reference blank node identifier then use the blank node identifier _:a,
+      // otherwise, use the blank node identifier _:z.
+      copy[key] = self.modifyFirstDegreeComponent(id, component, key);
+    });
+    nquads.push(_toNQuad(copy));
+    callback();
+  }, function(err) {
+    if(err) {
+      return callback(err);
+    }
+    // 4) Sort nquads in lexicographical order.
+    nquads.sort();
+
+    // 5) Return the hash that results from passing the sorted, joined nquads
+    // through the hash algorithm.
+    info.hash = NormalizeHash.hashNQuads(self.name, nquads);
+    callback(null, info.hash);
+  });
+};
+
+// helper for modifying component during Hash First Degree Quads
+Normalize.prototype.modifyFirstDegreeComponent = function(id, component) {
+  if(component.type !== 'blank node') {
+    return component;
+  }
+  component = _clone(component);
+  component.value = (component.value === id ? '_:a' : '_:z');
+  return component;
+};
+
+// 4.7) Hash Related Blank Node
+Normalize.prototype.hashRelatedBlankNode = function(
+  related, quad, issuer, position, callback) {
+  var self = this;
+
+  // 1) Set the identifier to use for related, preferring first the canonical
+  // identifier for related if issued, second the identifier issued by issuer
+  // if issued, and last, if necessary, the result of the Hash First Degree
+  // Quads algorithm, passing related.
+  var id;
+  self.waterfall([
+    function(callback) {
+      if(self.canonicalIssuer.hasId(related)) {
+        id = self.canonicalIssuer.getId(related);
+        return callback();
+      }
+      if(issuer.hasId(related)) {
+        id = issuer.getId(related);
+        return callback();
+      }
+      self.hashFirstDegreeQuads(related, function(err, hash) {
+        if(err) {
+          return callback(err);
+        }
+        id = hash;
+        callback();
+      });
+    }
+  ], function(err) {
+    if(err) {
+      return callback(err);
+    }
+
+    // 2) Initialize a string input to the value of position.
+    // Note: We use a hash object instead.
+    var md = new NormalizeHash(self.name);
+    md.update(position);
+
+    // 3) If position is not g, append <, the value of the predicate in quad,
+    // and > to input.
+    if(position !== 'g') {
+      md.update(self.getRelatedPredicate(quad));
+    }
+
+    // 4) Append identifier to input.
+    md.update(id);
+
+    // 5) Return the hash that results from passing input through the hash
+    // algorithm.
+    return callback(null, md.digest());
+  });
+};
+
+// helper for getting a related predicate
+Normalize.prototype.getRelatedPredicate = function(quad) {
+  return '<' + quad.predicate.value + '>';
+};
+
+// 4.8) Hash N-Degree Quads
+Normalize.prototype.hashNDegreeQuads = function(id, issuer, callback) {
+  var self = this;
+
+  // 1) Create a hash to related blank nodes map for storing hashes that
+  // identify related blank nodes.
+  // Note: 2) and 3) handled within `createHashToRelated`
+  var hashToRelated;
+  var md = new NormalizeHash(self.name);
+  self.waterfall([
+    function(callback) {
+      self.createHashToRelated(id, issuer, function(err, result) {
+        if(err) {
+          return callback(err);
+        }
+        hashToRelated = result;
+        callback();
+      });
+    },
+    function(callback) {
+      // 4) Create an empty string, data to hash.
+      // Note: We created a hash object `md` above instead.
+
+      // 5) For each related hash to blank node list mapping in hash to related
+      // blank nodes map, sorted lexicographically by related hash:
+      var hashes = Object.keys(hashToRelated).sort();
+      self.forEach(hashes, function(hash, idx, callback) {
+        // 5.1) Append the related hash to the data to hash.
+        md.update(hash);
+
+        // 5.2) Create a string chosen path.
+        var chosenPath = '';
+
+        // 5.3) Create an unset chosen issuer variable.
+        var chosenIssuer;
+
+        // 5.4) For each permutation of blank node list:
+        var permutator = new Permutator(hashToRelated[hash]);
+        self.whilst(function() {
+          return permutator.hasNext();
+        }, function(nextPermutation) {
+          var permutation = permutator.next();
+
+          // 5.4.1) Create a copy of issuer, issuer copy.
+          var issuerCopy = issuer.clone();
+
+          // 5.4.2) Create a string path.
+          var path = '';
+
+          // 5.4.3) Create a recursion list, to store blank node identifiers
+          // that must be recursively processed by this algorithm.
+          var recursionList = [];
+
+          self.waterfall([
+            function(callback) {
+              // 5.4.4) For each related in permutation:
+              self.forEach(permutation, function(related, idx, callback) {
+                // 5.4.4.1) If a canonical identifier has been issued for
+                // related, append it to path.
+                if(self.canonicalIssuer.hasId(related)) {
+                  path += self.canonicalIssuer.getId(related);
+                } else {
+                  // 5.4.4.2) Otherwise:
+                  // 5.4.4.2.1) If issuer copy has not issued an identifier for
+                  // related, append related to recursion list.
+                  if(!issuerCopy.hasId(related)) {
+                    recursionList.push(related);
+                  }
+                  // 5.4.4.2.2) Use the Issue Identifier algorithm, passing
+                  // issuer copy and related and append the result to path.
+                  path += issuerCopy.getId(related);
+                }
+
+                // 5.4.4.3) If chosen path is not empty and the length of path
+                // is greater than or equal to the length of chosen path and
+                // path is lexicographically greater than chosen path, then
+                // skip to the next permutation.
+                if(chosenPath.length !== 0 &&
+                  path.length >= chosenPath.length && path > chosenPath) {
+                  // FIXME: may cause inaccurate total depth calculation
+                  return nextPermutation();
+                }
+                callback();
+              }, callback);
+            },
+            function(callback) {
+              // 5.4.5) For each related in recursion list:
+              self.forEach(recursionList, function(related, idx, callback) {
+                // 5.4.5.1) Set result to the result of recursively executing
+                // the Hash N-Degree Quads algorithm, passing related for
+                // identifier and issuer copy for path identifier issuer.
+                self.hashNDegreeQuads(
+                  related, issuerCopy, function(err, result) {
+                  if(err) {
+                    return callback(err);
+                  }
+
+                  // 5.4.5.2) Use the Issue Identifier algorithm, passing issuer
+                  // copy and related and append the result to path.
+                  path += issuerCopy.getId(related);
+
+                  // 5.4.5.3) Append <, the hash in result, and > to path.
+                  path += '<' + result.hash + '>';
+
+                  // 5.4.5.4) Set issuer copy to the identifier issuer in
+                  // result.
+                  issuerCopy = result.issuer;
+
+                  // 5.4.5.5) If chosen path is not empty and the length of path
+                  // is greater than or equal to the length of chosen path and
+                  // path is lexicographically greater than chosen path, then
+                  // skip to the next permutation.
+                  if(chosenPath.length !== 0 &&
+                    path.length >= chosenPath.length && path > chosenPath) {
+                    // FIXME: may cause inaccurate total depth calculation
+                    return nextPermutation();
+                  }
+                  callback();
+                });
+              }, callback);
+            },
+            function(callback) {
+              // 5.4.6) If chosen path is empty or path is lexicographically
+              // less than chosen path, set chosen path to path and chosen
+              // issuer to issuer copy.
+              if(chosenPath.length === 0 || path < chosenPath) {
+                chosenPath = path;
+                chosenIssuer = issuerCopy;
+              }
+              callback();
+            }
+          ], nextPermutation);
+        }, function(err) {
+          if(err) {
+            return callback(err);
+          }
+
+          // 5.5) Append chosen path to data to hash.
+          md.update(chosenPath);
+
+          // 5.6) Replace issuer, by reference, with chosen issuer.
+          issuer = chosenIssuer;
+          callback();
+        });
+      }, callback);
+    }
+  ], function(err) {
+    // 6) Return issuer and the hash that results from passing data to hash
+    // through the hash algorithm.
+    callback(err, {hash: md.digest(), issuer: issuer});
+  });
+};
+
+// helper for creating hash to related blank nodes map
+Normalize.prototype.createHashToRelated = function(id, issuer, callback) {
+  var self = this;
+
+  // 1) Create a hash to related blank nodes map for storing hashes that
+  // identify related blank nodes.
+  var hashToRelated = {};
+
+  // 2) Get a reference, quads, to the list of quads in the blank node to
+  // quads map for the key identifier.
+  var quads = self.blankNodeInfo[id].quads;
+
+  // 3) For each quad in quads:
+  self.forEach(quads, function(quad, idx, callback) {
+    // 3.1) For each component in quad, if component is the subject, object,
+    // and graph name and it is a blank node that is not identified by
+    // identifier:
+    self.forEach(quad, function(component, key, callback) {
+      if(key === 'predicate' ||
+        !(component.type === 'blank node' && component.value !== id)) {
+        return callback();
+      }
+      // 3.1.1) Set hash to the result of the Hash Related Blank Node
+      // algorithm, passing the blank node identifier for component as
+      // related, quad, path identifier issuer as issuer, and position as
+      // either s, o, or g based on whether component is a subject, object,
+      // graph name, respectively.
+      var related = component.value;
+      var position = POSITIONS[key];
+      self.hashRelatedBlankNode(
+        related, quad, issuer, position, function(err, hash) {
+        if(err) {
+          return callback(err);
+        }
+        // 3.1.2) Add a mapping of hash to the blank node identifier for
+        // component to hash to related blank nodes map, adding an entry as
+        // necessary.
+        if(hash in hashToRelated) {
+          hashToRelated[hash].push(related);
+        } else {
+          hashToRelated[hash] = [related];
+        }
+        callback();
+      });
+    }, callback);
+  }, function(err) {
+    callback(err, hashToRelated);
+  });
+};
+
+// helper that iterates over quad components (skips predicate)
+Normalize.prototype.forEachComponent = function(quad, op) {
+  for(var key in quad) {
+    // skip `predicate`
+    if(key === 'predicate') {
+      continue;
+    }
+    op(quad[key], key, quad);
+  }
+};
+
+return Normalize;
+
+})(); // end of define URDNA2015
+
+/////////////////////////////// DEFINE URGNA2012 //////////////////////////////
+
+var URGNA2012 = (function() {
+
+var Normalize = function(options) {
+  URDNA2015.call(this, options);
+  this.name = 'URGNA2012';
+};
+Normalize.prototype = new URDNA2015();
+
+// helper for modifying component during Hash First Degree Quads
+Normalize.prototype.modifyFirstDegreeComponent = function(id, component, key) {
+  if(component.type !== 'blank node') {
+    return component;
+  }
+  component = _clone(component);
+  if(key === 'name') {
+    component.value = '_:g';
+  } else {
+    component.value = (component.value === id ? '_:a' : '_:z');
+  }
+  return component;
+};
+
+// helper for getting a related predicate
+Normalize.prototype.getRelatedPredicate = function(quad) {
+  return quad.predicate.value;
+};
+
+// helper for creating hash to related blank nodes map
+Normalize.prototype.createHashToRelated = function(id, issuer, callback) {
+  var self = this;
+
+  // 1) Create a hash to related blank nodes map for storing hashes that
+  // identify related blank nodes.
+  var hashToRelated = {};
+
+  // 2) Get a reference, quads, to the list of quads in the blank node to
+  // quads map for the key identifier.
+  var quads = self.blankNodeInfo[id].quads;
+
+  // 3) For each quad in quads:
+  self.forEach(quads, function(quad, idx, callback) {
+    // 3.1) If the quad's subject is a blank node that does not match
+    // identifier, set hash to the result of the Hash Related Blank Node
+    // algorithm, passing the blank node identifier for subject as related,
+    // quad, path identifier issuer as issuer, and p as position.
+    var position;
+    var related;
+    if(quad.subject.type === 'blank node' && quad.subject.value !== id) {
+      related = quad.subject.value;
+      position = 'p';
+    } else if(quad.object.type === 'blank node' && quad.object.value !== id) {
+      // 3.2) Otherwise, if quad's object is a blank node that does not match
+      // identifier, to the result of the Hash Related Blank Node algorithm,
+      // passing the blank node identifier for object as related, quad, path
+      // identifier issuer as issuer, and r as position.
+      related = quad.object.value;
+      position = 'r';
+    } else {
+      // 3.3) Otherwise, continue to the next quad.
+      return callback();
+    }
+    // 3.4) Add a mapping of hash to the blank node identifier for the
+    // component that matched (subject or object) to hash to related blank
+    // nodes map, adding an entry as necessary.
+    self.hashRelatedBlankNode(
+      related, quad, issuer, position, function(err, hash) {
+      if(hash in hashToRelated) {
+        hashToRelated[hash].push(related);
+      } else {
+        hashToRelated[hash] = [related];
+      }
+      callback();
+    });
+  }, function(err) {
+    callback(err, hashToRelated);
+  });
+};
+
+return Normalize;
+
+})(); // end of define URGNA2012
 
 /**
  * Recursively flattens the subjects in the given JSON-LD expanded input
@@ -4126,15 +4706,15 @@ function _getAdjacentBlankNodeName(node, id) {
  * @param input the JSON-LD expanded input.
  * @param graphs a map of graph name to subject map.
  * @param graph the name of the current graph.
- * @param namer the blank node namer.
+ * @param issuer the blank node identifier issuer.
  * @param name the name assigned to the current input if it is a bnode.
  * @param list the list to append to, null for none.
  */
-function _createNodeMap(input, graphs, graph, namer, name, list) {
+function _createNodeMap(input, graphs, graph, issuer, name, list) {
   // recurse through array
   if(_isArray(input)) {
     for(var i = 0; i < input.length; ++i) {
-      _createNodeMap(input[i], graphs, graph, namer, undefined, list);
+      _createNodeMap(input[i], graphs, graph, issuer, undefined, list);
     }
     return;
   }
@@ -4153,7 +4733,7 @@ function _createNodeMap(input, graphs, graph, namer, name, list) {
       var type = input['@type'];
       // rename @type blank node
       if(type.indexOf('_:') === 0) {
-        input['@type'] = type = namer.getName(type);
+        input['@type'] = type = issuer.getId(type);
       }
     }
     if(list) {
@@ -4170,14 +4750,14 @@ function _createNodeMap(input, graphs, graph, namer, name, list) {
     for(var i = 0; i < types.length; ++i) {
       var type = types[i];
       if(type.indexOf('_:') === 0) {
-        namer.getName(type);
+        issuer.getId(type);
       }
     }
   }
 
   // get name for subject
   if(_isUndefined(name)) {
-    name = _isBlankNode(input) ? namer.getName(input['@id']) : input['@id'];
+    name = _isBlankNode(input) ? issuer.getId(input['@id']) : input['@id'];
   }
 
   // add subject reference to list
@@ -4208,9 +4788,9 @@ function _createNodeMap(input, graphs, graph, namer, name, list) {
           var item = items[ii];
           var itemName = item['@id'];
           if(_isBlankNode(item)) {
-            itemName = namer.getName(itemName);
+            itemName = issuer.getId(itemName);
           }
-          _createNodeMap(item, graphs, graph, namer, itemName);
+          _createNodeMap(item, graphs, graph, issuer, itemName);
           jsonld.addValue(
             subjects[itemName], reverseProperty, referencedNode,
             {propertyIsArray: true, allowDuplicate: false});
@@ -4226,13 +4806,15 @@ function _createNodeMap(input, graphs, graph, namer, name, list) {
         graphs[name] = {};
       }
       var g = (graph === '@merged') ? graph : name;
-      _createNodeMap(input[property], graphs, g, namer);
+      _createNodeMap(input[property], graphs, g, issuer);
       continue;
     }
 
     // copy non-@type keywords
     if(property !== '@type' && _isKeyword(property)) {
-      if(property === '@index' && '@index' in subject) {
+      if(property === '@index' && property in subject &&
+        (input[property] !== subject[property] ||
+        input[property]['@id'] !== subject[property]['@id'])) {
         throw new JsonLdError(
           'Invalid JSON-LD syntax; conflicting @index property detected.',
           'jsonld.SyntaxError',
@@ -4247,7 +4829,7 @@ function _createNodeMap(input, graphs, graph, namer, name, list) {
 
     // if property is a bnode, assign it a new id
     if(property.indexOf('_:') === 0) {
-      property = namer.getName(property);
+      property = issuer.getId(property);
     }
 
     // ensure property is added for empty arrays
@@ -4260,30 +4842,30 @@ function _createNodeMap(input, graphs, graph, namer, name, list) {
 
       if(property === '@type') {
         // rename @type blank nodes
-        o = (o.indexOf('_:') === 0) ? namer.getName(o) : o;
+        o = (o.indexOf('_:') === 0) ? issuer.getId(o) : o;
       }
 
       // handle embedded subject or subject reference
       if(_isSubject(o) || _isSubjectReference(o)) {
-        // rename blank node @id
-        var id = _isBlankNode(o) ? namer.getName(o['@id']) : o['@id'];
+        // relabel blank node @id
+        var id = _isBlankNode(o) ? issuer.getId(o['@id']) : o['@id'];
 
         // add reference and recurse
         jsonld.addValue(
           subject, property, {'@id': id},
           {propertyIsArray: true, allowDuplicate: false});
-        _createNodeMap(o, graphs, graph, namer, id);
+        _createNodeMap(o, graphs, graph, issuer, id);
       } else if(_isList(o)) {
         // handle @list
         var _list = [];
-        _createNodeMap(o['@list'], graphs, graph, namer, name, _list);
+        _createNodeMap(o['@list'], graphs, graph, issuer, name, _list);
         o = {'@list': _list};
         jsonld.addValue(
           subject, property, o,
           {propertyIsArray: true, allowDuplicate: false});
       } else {
         // handle @value
-        _createNodeMap(o, graphs, graph, namer, name);
+        _createNodeMap(o, graphs, graph, issuer, name);
         jsonld.addValue(
           subject, property, o, {propertyIsArray: true, allowDuplicate: false});
       }
@@ -4350,7 +4932,7 @@ function _frame(state, subjects, frame, parent, property) {
 
   // add matches to output
   var ids = Object.keys(matches).sort();
-  for(var idx in ids) {
+  for(var idx = 0; idx < ids.length; ++idx) {
     var id = ids[idx];
     var subject = matches[id];
 
@@ -4913,13 +5495,18 @@ function _compactIri(activeCtx, iri, value, relativeTo, reverse) {
   }
   relativeTo = relativeTo || {};
 
-  // if term is a keyword, default vocab to true
+  var inverseCtx = activeCtx.getInverse();
+
+  // if term is a keyword, it can only be compacted to a simple alias
   if(_isKeyword(iri)) {
-    relativeTo.vocab = true;
+    if(iri in inverseCtx) {
+      return inverseCtx[iri]['@none']['@type']['@none'];
+    }
+    return iri;
   }
 
   // use inverse context to pick a term if iri is relative to vocab
-  if(relativeTo.vocab && iri in activeCtx.getInverse()) {
+  if(relativeTo.vocab && iri in inverseCtx) {
     var defaultLanguage = activeCtx['@language'] || '@none';
 
     // prefer @index if available in value
@@ -5027,32 +5614,37 @@ function _compactIri(activeCtx, iri, value, relativeTo, reverse) {
 
   // no term or @vocab match, check for possible CURIEs
   var choice = null;
-  for(var term in activeCtx.mappings) {
-    // skip terms with colons, they can't be prefixes
-    if(term.indexOf(':') !== -1) {
-      continue;
+  var idx = 0;
+  var partialMatches = [];
+  var iriMap = activeCtx.fastCurieMap;
+  // check for partial matches of against `iri`, which means look until
+  // iri.length - 1, not full length
+  var maxPartialLength = iri.length - 1;
+  for(; idx < maxPartialLength && iri[idx] in iriMap; ++idx) {
+    iriMap = iriMap[iri[idx]];
+    if('' in iriMap) {
+      partialMatches.push(iriMap[''][0]);
     }
-    // skip entries with @ids that are not partial matches
-    var definition = activeCtx.mappings[term];
-    if(!definition ||
-      definition['@id'] === iri || iri.indexOf(definition['@id']) !== 0) {
-      continue;
-    }
+  }
+  // check partial matches in reverse order to prefer longest ones first
+  for(var i = partialMatches.length - 1; i >= 0; --i) {
+    var entry = partialMatches[i];
+    var terms = entry.terms;
+    for(var ti = 0; ti < terms.length; ++ti) {
+      // a CURIE is usable if:
+      // 1. it has no mapping, OR
+      // 2. value is null, which means we're not compacting an @value, AND
+      //   the mapping matches the IRI
+      var curie = terms[ti] + ':' + iri.substr(entry.iri.length);
+      var isUsableCurie = (!(curie in activeCtx.mappings) ||
+        (value === null && activeCtx.mappings[curie]['@id'] === iri));
 
-    // a CURIE is usable if:
-    // 1. it has no mapping, OR
-    // 2. value is null, which means we're not compacting an @value, AND
-    //   the mapping matches the IRI)
-    var curie = term + ':' + iri.substr(definition['@id'].length);
-    var isUsableCurie = (!(curie in activeCtx.mappings) ||
-      (value === null && activeCtx.mappings[curie] &&
-      activeCtx.mappings[curie]['@id'] === iri));
-
-    // select curie if it is shorter or the same length but lexicographically
-    // less than the current choice
-    if(isUsableCurie && (choice === null ||
-      _compareShortestLeast(curie, choice) < 0)) {
-      choice = curie;
+      // select curie if it is shorter or the same length but lexicographically
+      // less than the current choice
+      if(isUsableCurie && (choice === null ||
+        _compareShortestLeast(curie, choice) < 0)) {
+        choice = curie;
+      }
     }
   }
 
@@ -5275,10 +5867,14 @@ function _createTermDefinition(activeCtx, localCtx, term, defined) {
     }
   }
 
+  // always compute whether term has a colon as an optimization for
+  // _compactIri
+  var colon = term.indexOf(':');
+  mapping._termHasColon = (colon !== -1);
+
   if(!('@id' in mapping)) {
     // see if the term has a prefix
-    var colon = term.indexOf(':');
-    if(colon !== -1) {
+    if(mapping._termHasColon) {
       var prefix = term.substr(0, colon);
       if(prefix in localCtx) {
         // define parent prefix
@@ -5412,6 +6008,9 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined) {
     return value;
   }
 
+  // ensure value is interpreted as a string
+  value = String(value);
+
   // define term dependency if not defined
   if(localCtx && value in localCtx && defined[value] !== true) {
     _createTermDefinition(activeCtx, localCtx, value, defined);
@@ -5467,20 +6066,12 @@ function _expandIri(activeCtx, value, relativeTo, localCtx, defined) {
   // prepend base
   var rval = value;
   if(relativeTo.base) {
-    rval = _prependBase(activeCtx['@base'], rval);
+    rval = jsonld.prependBase(activeCtx['@base'], rval);
   }
 
   return rval;
 }
 
-/**
- * Prepends a base IRI to the given relative IRI.
- *
- * @param base the base IRI.
- * @param iri the relative IRI.
- *
- * @return the absolute IRI.
- */
 function _prependBase(base, iri) {
   // skip IRI processing
   if(base === null) {
@@ -5676,6 +6267,10 @@ function _getInitialContext(options) {
     }
     var inverse = activeCtx.inverse = {};
 
+    // variables for building fast CURIE map
+    var fastCurieMap = activeCtx.fastCurieMap = {};
+    var irisToTerms = {};
+
     // handle default language
     var defaultLanguage = activeCtx['@language'] || '@none';
 
@@ -5700,10 +6295,25 @@ function _getInitialContext(options) {
       for(var ii = 0; ii < ids.length; ++ii) {
         var iri = ids[ii];
         var entry = inverse[iri];
+        var isKeyword = _isKeyword(iri);
 
-        // initialize entry
         if(!entry) {
+          // initialize entry
           inverse[iri] = entry = {};
+
+          if(!isKeyword && !mapping._termHasColon) {
+            // init IRI to term map and fast CURIE prefixes
+            irisToTerms[iri] = [term];
+            var fastCurieEntry = {iri: iri, terms: irisToTerms[iri]};
+            if(iri[0] in fastCurieMap) {
+              fastCurieMap[iri[0]].push(fastCurieEntry);
+            } else {
+              fastCurieMap[iri[0]] = [fastCurieEntry];
+            }
+          }
+        } else if(!isKeyword && !mapping._termHasColon) {
+          // add IRI to term match
+          irisToTerms[iri].push(term);
         }
 
         // add new entry
@@ -5738,7 +6348,48 @@ function _getInitialContext(options) {
       }
     }
 
+    // build fast CURIE map
+    for(var key in fastCurieMap) {
+      _buildIriMap(fastCurieMap, key, 1);
+    }
+
     return inverse;
+  }
+
+  /**
+   * Runs a recursive algorithm to build a lookup map for quickly finding
+   * potential CURIEs.
+   *
+   * @param iriMap the map to build.
+   * @param key the current key in the map to work on.
+   * @param idx the index into the IRI to compare.
+   */
+  function _buildIriMap(iriMap, key, idx) {
+    var entries = iriMap[key];
+    var next = iriMap[key] = {};
+
+    var iri;
+    var letter;
+    for(var i = 0; i < entries.length; ++i) {
+      iri = entries[i].iri;
+      if(idx >= iri.length) {
+        letter = '';
+      } else {
+        letter = iri[idx];
+      }
+      if(letter in next) {
+        next[letter].push(entries[i]);
+      } else {
+        next[letter] = [entries[i]];
+      }
+    }
+
+    for(var key in next) {
+      if(key === '') {
+        continue;
+      }
+      _buildIriMap(next, key, idx + 1);
+    }
   }
 
   /**
@@ -6108,7 +6759,7 @@ function _findContextUrls(input, urls, replace, base) {
         for(var i = 0; i < length; ++i) {
           var _ctx = ctx[i];
           if(_isString(_ctx)) {
-            _ctx = _prependBase(base, _ctx);
+            _ctx = jsonld.prependBase(base, _ctx);
             // replace w/@context if requested
             if(replace) {
               _ctx = urls[_ctx];
@@ -6128,7 +6779,7 @@ function _findContextUrls(input, urls, replace, base) {
         }
       } else if(_isString(ctx)) {
         // string @context
-        ctx = _prependBase(base, ctx);
+        ctx = jsonld.prependBase(base, ctx);
         // replace w/@context if requested
         if(replace) {
           input[key] = urls[ctx];
@@ -6181,7 +6832,7 @@ function _retrieveContextUrls(input, options, callback) {
     // find all URLs in the given input
     if(!_findContextUrls(input, urls, false, base)) {
       // no new URLs in input
-      finished();
+      return finished();
     }
 
     // queue all unretrieved URLs
@@ -6314,10 +6965,11 @@ function _parseNQuads(input) {
   var datatype = '(?:\\^\\^' + iri + ')';
   var language = '(?:@([a-z]+(?:-[a-z0-9]+)*))';
   var literal = '(?:' + plain + '(?:' + datatype + '|' + language + ')?)';
+  var comment = '(?:#.*)?';
   var ws = '[ \\t]+';
   var wso = '[ \\t]*';
   var eoln = /(?:\r\n)|(?:\n)|(?:\r)/g;
-  var empty = new RegExp('^' + wso + '$');
+  var empty = new RegExp('^' + wso + comment + '$');
 
   // define quad part regexes
   var subject = '(?:' + iri + '|' + bnode + ')' + ws;
@@ -6327,7 +6979,7 @@ function _parseNQuads(input) {
 
   // full quad regex
   var quad = new RegExp(
-    '^' + wso + subject + property + object + graphName + wso + '$');
+    '^' + wso + subject + property + object + graphName + wso + comment + '$');
 
   // build RDF dataset
   var dataset = {};
@@ -6440,37 +7092,36 @@ function _toNQuads(dataset) {
       quads.push(_toNQuad(triple, graphName));
     }
   }
-  quads.sort();
-  return quads.join('');
+  return quads.sort().join('');
 }
 
 /**
  * Converts an RDF triple and graph name to an N-Quad string (a single quad).
  *
- * @param triple the RDF triple to convert.
+ * @param triple the RDF triple or quad to convert (a triple or quad may be
+ *          passed, if a triple is passed then `graphName` should be given
+ *          to specify the name of the graph the triple is in, `null` for
+ *          the default graph).
  * @param graphName the name of the graph containing the triple, null for
  *          the default graph.
- * @param bnode the bnode the quad is mapped to (optional, for use
- *          during normalization only).
  *
  * @return the N-Quad string.
  */
-function _toNQuad(triple, graphName, bnode) {
+function _toNQuad(triple, graphName) {
   var s = triple.subject;
   var p = triple.predicate;
   var o = triple.object;
-  var g = graphName;
+  var g = graphName || null;
+  if('name' in triple && triple.name) {
+    g = triple.name.value;
+  }
 
   var quad = '';
 
   // subject is an IRI
   if(s.type === 'IRI') {
     quad += '<' + s.value + '>';
-  } else if(bnode) {
-    // bnode normalization mode
-    quad += (s.value === bnode) ? '_:a' : '_:z';
   } else {
-    // bnode normal mode
     quad += s.value;
   }
   quad += ' ';
@@ -6478,12 +7129,7 @@ function _toNQuad(triple, graphName, bnode) {
   // predicate is an IRI
   if(p.type === 'IRI') {
     quad += '<' + p.value + '>';
-  } else if(bnode) {
-    // FIXME: TBD what to do with bnode predicates during normalization
-    // bnode normalization mode
-    quad += '_:p';
   } else {
-    // bnode normal mode
     quad += p.value;
   }
   quad += ' ';
@@ -6492,13 +7138,7 @@ function _toNQuad(triple, graphName, bnode) {
   if(o.type === 'IRI') {
     quad += '<' + o.value + '>';
   } else if(o.type === 'blank node') {
-    // normalization mode
-    if(bnode) {
-      quad += (o.value === bnode) ? '_:a' : '_:z';
-    } else {
-      // normal mode
-      quad += o.value;
-    }
+    quad += o.value;
   } else {
     var escaped = o.value
       .replace(/\\/g, '\\\\')
@@ -6517,11 +7157,9 @@ function _toNQuad(triple, graphName, bnode) {
   }
 
   // graph
-  if(g !== null) {
+  if(g !== null && g !== undefined) {
     if(g.indexOf('_:') !== 0) {
       quad += ' <' + g + '>';
-    } else if(bnode) {
-      quad += ' _:g';
     } else {
       quad += ' ' + g;
     }
@@ -6635,66 +7273,74 @@ function _parseRdfaApiData(data) {
 jsonld.registerRDFParser('rdfa-api', _parseRdfaApiData);
 
 /**
- * Creates a new UniqueNamer. A UniqueNamer issues unique names, keeping
- * track of any previously issued names.
+ * Creates a new IdentifierIssuer. A IdentifierIssuer issues unique
+ * identifiers, keeping track of any previously issued identifiers.
  *
  * @param prefix the prefix to use ('<prefix><counter>').
  */
-function UniqueNamer(prefix) {
+function IdentifierIssuer(prefix) {
   this.prefix = prefix;
   this.counter = 0;
   this.existing = {};
 }
-jsonld.UniqueNamer = UniqueNamer;
+jsonld.IdentifierIssuer = IdentifierIssuer;
+// backwards-compability
+jsonld.UniqueNamer = IdentifierIssuer;
 
 /**
- * Copies this UniqueNamer.
+ * Copies this IdentifierIssuer.
  *
- * @return a copy of this UniqueNamer.
+ * @return a copy of this IdentifierIssuer.
  */
-UniqueNamer.prototype.clone = function() {
-  var copy = new UniqueNamer(this.prefix);
+IdentifierIssuer.prototype.clone = function() {
+  var copy = new IdentifierIssuer(this.prefix);
   copy.counter = this.counter;
   copy.existing = _clone(this.existing);
   return copy;
 };
 
 /**
- * Gets the new name for the given old name, where if no old name is given
- * a new name will be generated.
+ * Gets the new identifier for the given old identifier, where if no old
+ * identifier is given a new identifier will be generated.
  *
- * @param [oldName] the old name to get the new name for.
+ * @param [old] the old identifier to get the new identifier for.
  *
- * @return the new name.
+ * @return the new identifier.
  */
-UniqueNamer.prototype.getName = function(oldName) {
-  // return existing old name
-  if(oldName && oldName in this.existing) {
-    return this.existing[oldName];
+IdentifierIssuer.prototype.getId = function(old) {
+  // return existing old identifier
+  if(old && old in this.existing) {
+    return this.existing[old];
   }
 
-  // get next name
-  var name = this.prefix + this.counter;
+  // get next identifier
+  var identifier = this.prefix + this.counter;
   this.counter += 1;
 
   // save mapping
-  if(oldName) {
-    this.existing[oldName] = name;
+  if(old) {
+    this.existing[old] = identifier;
   }
 
-  return name;
+  return identifier;
 };
+// alias
+IdentifierIssuer.prototype.getName = IdentifierIssuer.prototype.getName;
 
 /**
- * Returns true if the given oldName has already been assigned a new name.
+ * Returns true if the given old identifer has already been assigned a new
+ * identifier.
  *
- * @param oldName the oldName to check.
+ * @param old the old identifier to check.
  *
- * @return true if the oldName has been assigned a new name, false if not.
+ * @return true if the old identifier has been assigned a new identifier, false
+ *   if not.
  */
-UniqueNamer.prototype.isNamed = function(oldName) {
-  return (oldName in this.existing);
+IdentifierIssuer.prototype.hasId = function(old) {
+  return (old in this.existing);
 };
+// alias
+IdentifierIssuer.prototype.isNamed = IdentifierIssuer.prototype.hasId;
 
 /**
  * A Permutator iterates over all possible permutations of the given array
@@ -6772,52 +7418,250 @@ Permutator.prototype.next = function() {
   return rval;
 };
 
-// SHA-1 API
-var sha1 = jsonld.sha1 = {};
-
-if(_nodejs) {
-  var crypto = require('crypto');
-  sha1.create = function() {
-    var md = crypto.createHash('sha1');
-    return {
-      update: function(data) {
-        md.update(data, 'utf8');
-      },
-      digest: function() {
-        return md.digest('hex');
-      }
-    };
-  };
-} else {
-  sha1.create = function() {
-    return new sha1.MessageDigest();
-  };
-}
+//////////////////////// DEFINE NORMALIZATION HASH API ////////////////////////
 
 /**
- * Hashes the given array of quads and returns its hexadecimal SHA-1 message
- * digest.
+ * Creates a new NormalizeHash for use by the given normalization algorithm.
  *
- * @param nquads the list of serialized quads to hash.
- *
- * @return the hexadecimal SHA-1 message digest.
+ * @param algorithm the RDF Dataset Normalization algorithm to use:
+ *          'URDNA2015' or 'URGNA2012'.
  */
-sha1.hash = function(nquads) {
-  var md = sha1.create();
+var NormalizeHash = function(algorithm) {
+  if(!(this instanceof NormalizeHash)) {
+    return new NormalizeHash(algorithm);
+  }
+  if(['URDNA2015', 'URGNA2012'].indexOf(algorithm) === -1) {
+    throw new Error(
+      'Invalid RDF Dataset Normalization algorithm: ' + algorithm);
+  }
+  NormalizeHash._init.call(this, algorithm);
+};
+NormalizeHash.hashNQuads = function(algorithm, nquads) {
+  var md = new NormalizeHash(algorithm);
   for(var i = 0; i < nquads.length; ++i) {
     md.update(nquads[i]);
   }
   return md.digest();
 };
 
-// only define sha1 MessageDigest for non-nodejs
-if(!_nodejs) {
+// switch definition of NormalizeHash based on environment
+(function(_nodejs) {
+
+if(_nodejs) {
+  // define NormalizeHash using native crypto lib
+  var crypto = require('crypto');
+  NormalizeHash._init = function(algorithm) {
+    if(algorithm === 'URDNA2015') {
+      algorithm = 'sha256';
+    } else {
+      // assume URGNA2012
+      algorithm = 'sha1';
+    }
+    this.md = crypto.createHash(algorithm);
+  };
+  NormalizeHash.prototype.update = function(msg) {
+    return this.md.update(msg, 'utf8');
+  };
+  NormalizeHash.prototype.digest = function() {
+    return this.md.digest('hex');
+  };
+  return;
+}
+
+// define NormalizeHash using JavaScript
+NormalizeHash._init = function(algorithm) {
+  if(algorithm === 'URDNA2015') {
+    algorithm = new sha256.Algorithm();
+  } else {
+    // assume URGNA2012
+    algorithm = new sha1.Algorithm();
+  }
+  this.md = new MessageDigest(algorithm);
+};
+NormalizeHash.prototype.update = function(msg) {
+  return this.md.update(msg);
+};
+NormalizeHash.prototype.digest = function() {
+  return this.md.digest().toHex();
+};
+
+/////////////////////////// DEFINE MESSAGE DIGEST API /////////////////////////
+
+/**
+ * Creates a new MessageDigest.
+ *
+ * @param algorithm the algorithm to use.
+ */
+var MessageDigest = function(algorithm) {
+  if(!(this instanceof MessageDigest)) {
+    return new MessageDigest(algorithm);
+  }
+
+  this._algorithm = algorithm;
+
+  // create shared padding as needed
+  if(!MessageDigest._padding ||
+    MessageDigest._padding.length < this._algorithm.blockSize) {
+    MessageDigest._padding = String.fromCharCode(128);
+    var c = String.fromCharCode(0x00);
+    var n = 64;
+    while(n > 0) {
+      if(n & 1) {
+        MessageDigest._padding += c;
+      }
+      n >>>= 1;
+      if(n > 0) {
+        c += c;
+      }
+    }
+  }
+
+  // start digest automatically for first time
+  this.start();
+};
+
+/**
+ * Starts the digest.
+ *
+ * @return this digest object.
+ */
+MessageDigest.prototype.start = function() {
+  // up to 56-bit message length for convenience
+  this.messageLength = 0;
+
+  // full message length
+  this.fullMessageLength = [];
+  var int32s = this._algorithm.messageLengthSize / 4;
+  for(var i = 0; i < int32s; ++i) {
+    this.fullMessageLength.push(0);
+  }
+
+  // input buffer
+  this._input = new MessageDigest.ByteBuffer();
+
+  // get starting state
+  this.state = this._algorithm.start();
+
+  return this;
+};
+
+/**
+ * Updates the digest with the given message input. The input must be
+ * a string of characters.
+ *
+ * @param msg the message input to update with (ByteBuffer or string).
+ *
+ * @return this digest object.
+ */
+MessageDigest.prototype.update = function(msg) {
+  // encode message as a UTF-8 encoded binary string
+  msg = new MessageDigest.ByteBuffer(unescape(encodeURIComponent(msg)));
+
+  // update message length
+  this.messageLength += msg.length();
+  var len = msg.length();
+  len = [(len / 0x100000000) >>> 0, len >>> 0];
+  for(var i = this.fullMessageLength.length - 1; i >= 0; --i) {
+    this.fullMessageLength[i] += len[1];
+    len[1] = len[0] + ((this.fullMessageLength[i] / 0x100000000) >>> 0);
+    this.fullMessageLength[i] = this.fullMessageLength[i] >>> 0;
+    len[0] = ((len[1] / 0x100000000) >>> 0);
+  }
+
+  // add bytes to input buffer
+  this._input.putBytes(msg.bytes());
+
+  // digest blocks
+  while(this._input.length() >= this._algorithm.blockSize) {
+    this.state = this._algorithm.digest(this.state, this._input);
+  }
+
+  // compact input buffer every 2K or if empty
+  if(this._input.read > 2048 || this._input.length() === 0) {
+    this._input.compact();
+  }
+
+  return this;
+};
+
+/**
+ * Produces the digest.
+ *
+ * @return a byte buffer containing the digest value.
+ */
+MessageDigest.prototype.digest = function() {
+  /* Note: Here we copy the remaining bytes in the input buffer and add the
+  appropriate padding. Then we do the final update on a copy of the state so
+  that if the user wants to get intermediate digests they can do so. */
+
+  /* Determine the number of bytes that must be added to the message to
+  ensure its length is appropriately congruent. In other words, the data to
+  be digested must be a multiple of `blockSize`. This data includes the
+  message, some padding, and the length of the message. Since the length of
+  the message will be encoded as `messageLengthSize` bytes, that means that
+  the last segment of the data must have `blockSize` - `messageLengthSize`
+  bytes of message and padding. Therefore, the length of the message plus the
+  padding must be congruent to X mod `blockSize` because
+  `blockSize` - `messageLengthSize` = X.
+
+  For example, SHA-1 is congruent to 448 mod 512 and SHA-512 is congruent to
+  896 mod 1024. SHA-1 uses a `blockSize` of 64 bytes (512 bits) and a
+  `messageLengthSize` of 8 bytes (64 bits). SHA-512 uses a `blockSize` of
+  128 bytes (1024 bits) and a `messageLengthSize` of 16 bytes (128 bits).
+
+  In order to fill up the message length it must be filled with padding that
+  begins with 1 bit followed by all 0 bits. Padding must *always* be present,
+  so if the message length is already congruent, then `blockSize` padding bits
+  must be added. */
+
+  // create final block
+  var finalBlock = new MessageDigest.ByteBuffer();
+  finalBlock.putBytes(this._input.bytes());
+
+  // compute remaining size to be digested (include message length size)
+  var remaining = (
+    this.fullMessageLength[this.fullMessageLength.length - 1] +
+    this._algorithm.messageLengthSize);
+
+  // add padding for overflow blockSize - overflow
+  // _padding starts with 1 byte with first bit is set (byte value 128), then
+  // there may be up to (blockSize - 1) other pad bytes
+  var overflow = remaining & (this._algorithm.blockSize - 1);
+  finalBlock.putBytes(MessageDigest._padding.substr(
+    0, this._algorithm.blockSize - overflow));
+
+  // serialize message length in bits in big-endian order; since length
+  // is stored in bytes we multiply by 8 (left shift by 3 and merge in
+  // remainder from )
+  var messageLength = new MessageDigest.ByteBuffer();
+  for(var i = 0; i < this.fullMessageLength.length; ++i) {
+    messageLength.putInt32((this.fullMessageLength[i] << 3) |
+      (this.fullMessageLength[i + 1] >>> 28));
+  }
+
+  // write the length of the message (algorithm-specific)
+  this._algorithm.writeMessageLength(finalBlock, messageLength);
+
+  // digest final block
+  var state = this._algorithm.digest(this.state.copy(), finalBlock);
+
+  // write state to buffer
+  var rval = new MessageDigest.ByteBuffer();
+  state.write(rval);
+  return rval;
+};
 
 /**
  * Creates a simple byte buffer for message digest operations.
+ *
+ * @param data the data to put in the buffer.
  */
-sha1.Buffer = function() {
-  this.data = '';
+MessageDigest.ByteBuffer = function(data) {
+  if(typeof data === 'string') {
+    this.data = data;
+  } else {
+    this.data = '';
+  }
   this.read = 0;
 };
 
@@ -6826,7 +7670,7 @@ sha1.Buffer = function() {
  *
  * @param i the 32-bit integer.
  */
-sha1.Buffer.prototype.putInt32 = function(i) {
+MessageDigest.ByteBuffer.prototype.putInt32 = function(i) {
   this.data += (
     String.fromCharCode(i >> 24 & 0xFF) +
     String.fromCharCode(i >> 16 & 0xFF) +
@@ -6840,7 +7684,7 @@ sha1.Buffer.prototype.putInt32 = function(i) {
  *
  * @return the word.
  */
-sha1.Buffer.prototype.getInt32 = function() {
+MessageDigest.ByteBuffer.prototype.getInt32 = function() {
   var rval = (
     this.data.charCodeAt(this.read) << 24 ^
     this.data.charCodeAt(this.read + 1) << 16 ^
@@ -6851,11 +7695,20 @@ sha1.Buffer.prototype.getInt32 = function() {
 };
 
 /**
+ * Puts the given bytes into this buffer.
+ *
+ * @param bytes the bytes as a binary-encoded string.
+ */
+MessageDigest.ByteBuffer.prototype.putBytes = function(bytes) {
+  this.data += bytes;
+};
+
+/**
  * Gets the bytes in this buffer.
  *
  * @return a string full of UTF-8 encoded characters.
  */
-sha1.Buffer.prototype.bytes = function() {
+MessageDigest.ByteBuffer.prototype.bytes = function() {
   return this.data.slice(this.read);
 };
 
@@ -6864,14 +7717,14 @@ sha1.Buffer.prototype.bytes = function() {
  *
  * @return the number of bytes in this buffer.
  */
-sha1.Buffer.prototype.length = function() {
+MessageDigest.ByteBuffer.prototype.length = function() {
   return this.data.length - this.read;
 };
 
 /**
  * Compacts this buffer.
  */
-sha1.Buffer.prototype.compact = function() {
+MessageDigest.ByteBuffer.prototype.compact = function() {
   this.data = this.data.slice(this.read);
   this.read = 0;
 };
@@ -6881,7 +7734,7 @@ sha1.Buffer.prototype.compact = function() {
  *
  * @return a hexadecimal string.
  */
-sha1.Buffer.prototype.toHex = function() {
+MessageDigest.ByteBuffer.prototype.toHex = function() {
   var rval = '';
   for(var i = this.read; i < this.data.length; ++i) {
     var b = this.data.charCodeAt(i);
@@ -6893,148 +7746,39 @@ sha1.Buffer.prototype.toHex = function() {
   return rval;
 };
 
-/**
- * Creates a SHA-1 message digest object.
- *
- * @return a message digest object.
- */
-sha1.MessageDigest = function() {
-  // do initialization as necessary
-  if(!_sha1.initialized) {
-    _sha1.init();
-  }
+///////////////////////////// DEFINE SHA-1 ALGORITHM //////////////////////////
 
-  this.blockLength = 64;
+var sha1 = {
+  // used for word storage
+  _w: null
+};
+
+sha1.Algorithm = function() {
+  this.name = 'sha1',
+  this.blockSize = 64;
   this.digestLength = 20;
-  // length of message so far (does not including padding)
-  this.messageLength = 0;
-
-  // input buffer
-  this.input = new sha1.Buffer();
-
-  // for storing words in the SHA-1 algorithm
-  this.words = new Array(80);
-
-  // SHA-1 state contains five 32-bit integers
-  this.state = {
-    h0: 0x67452301,
-    h1: 0xEFCDAB89,
-    h2: 0x98BADCFE,
-    h3: 0x10325476,
-    h4: 0xC3D2E1F0
-  };
+  this.messageLengthSize = 8;
 };
 
-/**
- * Updates the digest with the given string input.
- *
- * @param msg the message input to update with.
- */
-sha1.MessageDigest.prototype.update = function(msg) {
-  // UTF-8 encode message
-  msg = unescape(encodeURIComponent(msg));
-
-  // update message length and input buffer
-  this.messageLength += msg.length;
-  this.input.data += msg;
-
-  // process input
-  _sha1.update(this.state, this.words, this.input);
-
-  // compact input buffer every 2K or if empty
-  if(this.input.read > 2048 || this.input.length() === 0) {
-    this.input.compact();
+sha1.Algorithm.prototype.start = function() {
+  if(!sha1._w) {
+    sha1._w = new Array(80);
   }
+  return sha1._createState();
 };
 
-/**
- * Produces the digest.
- *
- * @return the digest as a hexadecimal string.
- */
-sha1.MessageDigest.prototype.digest = function() {
-  /* Determine the number of bytes that must be added to the message
-  to ensure its length is congruent to 448 mod 512. In other words,
-  a 64-bit integer that gives the length of the message will be
-  appended to the message and whatever the length of the message is
-  plus 64 bits must be a multiple of 512. So the length of the
-  message must be congruent to 448 mod 512 because 512 - 64 = 448.
-
-  In order to fill up the message length it must be filled with
-  padding that begins with 1 bit followed by all 0 bits. Padding
-  must *always* be present, so if the message length is already
-  congruent to 448 mod 512, then 512 padding bits must be added. */
-
-  // 512 bits == 64 bytes, 448 bits == 56 bytes, 64 bits = 8 bytes
-  // _padding starts with 1 byte with first bit is set in it which
-  // is byte value 128, then there may be up to 63 other pad bytes
-  var len = this.messageLength;
-  var padBytes = new sha1.Buffer();
-  padBytes.data += this.input.bytes();
-  padBytes.data += _sha1.padding.substr(0, 64 - ((len + 8) % 64));
-
-  /* Now append length of the message. The length is appended in bits
-  as a 64-bit number in big-endian order. Since we store the length
-  in bytes, we must multiply it by 8 (or left shift by 3). So here
-  store the high 3 bits in the low end of the first 32-bits of the
-  64-bit number and the lower 5 bits in the high end of the second
-  32-bits. */
-  padBytes.putInt32((len >>> 29) & 0xFF);
-  padBytes.putInt32((len << 3) & 0xFFFFFFFF);
-  _sha1.update(this.state, this.words, padBytes);
-  var rval = new sha1.Buffer();
-  rval.putInt32(this.state.h0);
-  rval.putInt32(this.state.h1);
-  rval.putInt32(this.state.h2);
-  rval.putInt32(this.state.h3);
-  rval.putInt32(this.state.h4);
-  return rval.toHex();
+sha1.Algorithm.prototype.writeMessageLength = function(
+  finalBlock, messageLength) {
+  // message length is in bits and in big-endian order; simply append
+  finalBlock.putBytes(messageLength.bytes());
 };
 
-// private SHA-1 data
-var _sha1 = {
-  padding: null,
-  initialized: false
-};
-
-/**
- * Initializes the constant tables.
- */
-_sha1.init = function() {
-  // create padding
-  _sha1.padding = String.fromCharCode(128);
-  var c = String.fromCharCode(0x00);
-  var n = 64;
-  while(n > 0) {
-    if(n & 1) {
-      _sha1.padding += c;
-    }
-    n >>>= 1;
-    if(n > 0) {
-      c += c;
-    }
-  }
-
-  // now initialized
-  _sha1.initialized = true;
-};
-
-/**
- * Updates a SHA-1 state with the given byte buffer.
- *
- * @param s the SHA-1 state to update.
- * @param w the array to use to store words.
- * @param input the input byte buffer.
- */
-_sha1.update = function(s, w, input) {
+sha1.Algorithm.prototype.digest = function(s, input) {
   // consume 512 bit (64 byte) chunks
   var t, a, b, c, d, e, f, i;
   var len = input.length();
+  var _w = sha1._w;
   while(len >= 64) {
-    // the w array will be populated with sixteen 32-bit big-endian words
-    // and then extended into 80 32-bit words according to SHA-1 algorithm
-    // and for 32-79 using Max Locktyukhin's optimization
-
     // initialize hash value for this chunk
     a = s.h0;
     b = s.h1;
@@ -7042,10 +7786,14 @@ _sha1.update = function(s, w, input) {
     d = s.h3;
     e = s.h4;
 
+    // the _w array will be populated with sixteen 32-bit big-endian words
+    // and then extended into 80 32-bit words according to SHA-1 algorithm
+    // and for 32-79 using Max Locktyukhin's optimization
+
     // round 1
     for(i = 0; i < 16; ++i) {
       t = input.getInt32();
-      w[i] = t;
+      _w[i] = t;
       f = d ^ (b & (c ^ d));
       t = ((a << 5) | (a >>> 27)) + f + e + 0x5A827999 + t;
       e = d;
@@ -7055,9 +7803,9 @@ _sha1.update = function(s, w, input) {
       a = t;
     }
     for(; i < 20; ++i) {
-      t = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
+      t = (_w[i - 3] ^ _w[i - 8] ^ _w[i - 14] ^ _w[i - 16]);
       t = (t << 1) | (t >>> 31);
-      w[i] = t;
+      _w[i] = t;
       f = d ^ (b & (c ^ d));
       t = ((a << 5) | (a >>> 27)) + f + e + 0x5A827999 + t;
       e = d;
@@ -7068,9 +7816,9 @@ _sha1.update = function(s, w, input) {
     }
     // round 2
     for(; i < 32; ++i) {
-      t = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
+      t = (_w[i - 3] ^ _w[i - 8] ^ _w[i - 14] ^ _w[i - 16]);
       t = (t << 1) | (t >>> 31);
-      w[i] = t;
+      _w[i] = t;
       f = b ^ c ^ d;
       t = ((a << 5) | (a >>> 27)) + f + e + 0x6ED9EBA1 + t;
       e = d;
@@ -7080,9 +7828,9 @@ _sha1.update = function(s, w, input) {
       a = t;
     }
     for(; i < 40; ++i) {
-      t = (w[i - 6] ^ w[i - 16] ^ w[i - 28] ^ w[i - 32]);
+      t = (_w[i - 6] ^ _w[i - 16] ^ _w[i - 28] ^ _w[i - 32]);
       t = (t << 2) | (t >>> 30);
-      w[i] = t;
+      _w[i] = t;
       f = b ^ c ^ d;
       t = ((a << 5) | (a >>> 27)) + f + e + 0x6ED9EBA1 + t;
       e = d;
@@ -7093,9 +7841,9 @@ _sha1.update = function(s, w, input) {
     }
     // round 3
     for(; i < 60; ++i) {
-      t = (w[i - 6] ^ w[i - 16] ^ w[i - 28] ^ w[i - 32]);
+      t = (_w[i - 6] ^ _w[i - 16] ^ _w[i - 28] ^ _w[i - 32]);
       t = (t << 2) | (t >>> 30);
-      w[i] = t;
+      _w[i] = t;
       f = (b & c) | (d & (b ^ c));
       t = ((a << 5) | (a >>> 27)) + f + e + 0x8F1BBCDC + t;
       e = d;
@@ -7106,9 +7854,9 @@ _sha1.update = function(s, w, input) {
     }
     // round 4
     for(; i < 80; ++i) {
-      t = (w[i - 6] ^ w[i - 16] ^ w[i - 28] ^ w[i - 32]);
+      t = (_w[i - 6] ^ _w[i - 16] ^ _w[i - 28] ^ _w[i - 32]);
       t = (t << 2) | (t >>> 30);
-      w[i] = t;
+      _w[i] = t;
       f = b ^ c ^ d;
       t = ((a << 5) | (a >>> 27)) + f + e + 0xCA62C1D6 + t;
       e = d;
@@ -7119,17 +7867,218 @@ _sha1.update = function(s, w, input) {
     }
 
     // update hash state
-    s.h0 += a;
-    s.h1 += b;
-    s.h2 += c;
-    s.h3 += d;
-    s.h4 += e;
+    s.h0 = (s.h0 + a) | 0;
+    s.h1 = (s.h1 + b) | 0;
+    s.h2 = (s.h2 + c) | 0;
+    s.h3 = (s.h3 + d) | 0;
+    s.h4 = (s.h4 + e) | 0;
 
     len -= 64;
   }
+
+  return s;
 };
 
-} // end non-nodejs
+sha1._createState = function() {
+  var state = {
+    h0: 0x67452301,
+    h1: 0xEFCDAB89,
+    h2: 0x98BADCFE,
+    h3: 0x10325476,
+    h4: 0xC3D2E1F0
+  };
+  state.copy = function() {
+    var rval = sha1._createState();
+    rval.h0 = state.h0;
+    rval.h1 = state.h1;
+    rval.h2 = state.h2;
+    rval.h3 = state.h3;
+    rval.h4 = state.h4;
+    return rval;
+  };
+  state.write = function(buffer) {
+    buffer.putInt32(state.h0);
+    buffer.putInt32(state.h1);
+    buffer.putInt32(state.h2);
+    buffer.putInt32(state.h3);
+    buffer.putInt32(state.h4);
+  };
+  return state;
+};
+
+//////////////////////////// DEFINE SHA-256 ALGORITHM /////////////////////////
+
+var sha256 = {
+  // shared state
+  _k: null,
+  _w: null
+};
+
+sha256.Algorithm = function() {
+  this.name = 'sha256',
+  this.blockSize = 64;
+  this.digestLength = 32;
+  this.messageLengthSize = 8;
+};
+
+sha256.Algorithm.prototype.start = function() {
+  if(!sha256._k) {
+    sha256._init();
+  }
+  return sha256._createState();
+};
+
+sha256.Algorithm.prototype.writeMessageLength = function(
+  finalBlock, messageLength) {
+  // message length is in bits and in big-endian order; simply append
+  finalBlock.putBytes(messageLength.bytes());
+};
+
+sha256.Algorithm.prototype.digest = function(s, input) {
+  // consume 512 bit (64 byte) chunks
+  var t1, t2, s0, s1, ch, maj, i, a, b, c, d, e, f, g, h;
+  var len = input.length();
+  var _k = sha256._k;
+  var _w = sha256._w;
+  while(len >= 64) {
+    // the w array will be populated with sixteen 32-bit big-endian words
+    // and then extended into 64 32-bit words according to SHA-256
+    for(i = 0; i < 16; ++i) {
+      _w[i] = input.getInt32();
+    }
+    for(; i < 64; ++i) {
+      // XOR word 2 words ago rot right 17, rot right 19, shft right 10
+      t1 = _w[i - 2];
+      t1 =
+        ((t1 >>> 17) | (t1 << 15)) ^
+        ((t1 >>> 19) | (t1 << 13)) ^
+        (t1 >>> 10);
+      // XOR word 15 words ago rot right 7, rot right 18, shft right 3
+      t2 = _w[i - 15];
+      t2 =
+        ((t2 >>> 7) | (t2 << 25)) ^
+        ((t2 >>> 18) | (t2 << 14)) ^
+        (t2 >>> 3);
+      // sum(t1, word 7 ago, t2, word 16 ago) modulo 2^32
+      _w[i] = (t1 + _w[i - 7] + t2 + _w[i - 16]) | 0;
+    }
+
+    // initialize hash value for this chunk
+    a = s.h0;
+    b = s.h1;
+    c = s.h2;
+    d = s.h3;
+    e = s.h4;
+    f = s.h5;
+    g = s.h6;
+    h = s.h7;
+
+    // round function
+    for(i = 0; i < 64; ++i) {
+      // Sum1(e)
+      s1 =
+        ((e >>> 6) | (e << 26)) ^
+        ((e >>> 11) | (e << 21)) ^
+        ((e >>> 25) | (e << 7));
+      // Ch(e, f, g) (optimized the same way as SHA-1)
+      ch = g ^ (e & (f ^ g));
+      // Sum0(a)
+      s0 =
+        ((a >>> 2) | (a << 30)) ^
+        ((a >>> 13) | (a << 19)) ^
+        ((a >>> 22) | (a << 10));
+      // Maj(a, b, c) (optimized the same way as SHA-1)
+      maj = (a & b) | (c & (a ^ b));
+
+      // main algorithm
+      t1 = h + s1 + ch + _k[i] + _w[i];
+      t2 = s0 + maj;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + t1) | 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (t1 + t2) | 0;
+    }
+
+    // update hash state
+    s.h0 = (s.h0 + a) | 0;
+    s.h1 = (s.h1 + b) | 0;
+    s.h2 = (s.h2 + c) | 0;
+    s.h3 = (s.h3 + d) | 0;
+    s.h4 = (s.h4 + e) | 0;
+    s.h5 = (s.h5 + f) | 0;
+    s.h6 = (s.h6 + g) | 0;
+    s.h7 = (s.h7 + h) | 0;
+    len -= 64;
+  }
+
+  return s;
+};
+
+sha256._createState = function() {
+  var state = {
+    h0: 0x6A09E667,
+    h1: 0xBB67AE85,
+    h2: 0x3C6EF372,
+    h3: 0xA54FF53A,
+    h4: 0x510E527F,
+    h5: 0x9B05688C,
+    h6: 0x1F83D9AB,
+    h7: 0x5BE0CD19
+  };
+  state.copy = function() {
+    var rval = sha256._createState();
+    rval.h0 = state.h0;
+    rval.h1 = state.h1;
+    rval.h2 = state.h2;
+    rval.h3 = state.h3;
+    rval.h4 = state.h4;
+    rval.h5 = state.h5;
+    rval.h6 = state.h6;
+    rval.h7 = state.h7;
+    return rval;
+  };
+  state.write = function(buffer) {
+    buffer.putInt32(state.h0);
+    buffer.putInt32(state.h1);
+    buffer.putInt32(state.h2);
+    buffer.putInt32(state.h3);
+    buffer.putInt32(state.h4);
+    buffer.putInt32(state.h5);
+    buffer.putInt32(state.h6);
+    buffer.putInt32(state.h7);
+  };
+  return state;
+};
+
+sha256._init = function() {
+  // create K table for SHA-256
+  sha256._k = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2];
+
+  // used for word storage
+  sha256._w = new Array(64);
+};
+
+})(_nodejs); // end definition of NormalizeHash
 
 if(!XMLSerializer) {
 
@@ -7164,6 +8113,15 @@ jsonld.url.parse = function(str, parser) {
   while(i--) {
     parsed[o.keys[i]] = (m[i] === undefined) ? null : m[i];
   }
+
+  // remove default ports in found in URLs
+  if((parsed.scheme === 'https' && parsed.port === '443') ||
+    (parsed.scheme === 'http' && parsed.port === '80')) {
+    parsed.href = parsed.href.replace(':' + parsed.port, '');
+    parsed.authority = parsed.authority.replace(':' + parsed.port, '');
+    parsed.port = null;
+  }
+
   parsed.normalizedPath = _removeDotSegments(parsed.path, !!parsed.authority);
   return parsed;
 };
@@ -7208,7 +8166,7 @@ function _removeDotSegments(path, hasAuthority) {
 
 if(_nodejs) {
   // use node document loader by default
-//  jsonld.useDocumentLoader('node');
+  jsonld.useDocumentLoader('node');
 } else if(typeof XMLHttpRequest !== 'undefined') {
   // use xhr document loader by default
   jsonld.useDocumentLoader('xhr');
@@ -7217,9 +8175,10 @@ if(_nodejs) {
 if(_nodejs) {
   jsonld.use = function(extension) {
     switch(extension) {
+      // TODO: Deprecated as of 0.4.0. Remove at some point.
       case 'request':
         // use node JSON-LD request extension
-        jsonld.request = require('./request');
+        jsonld.request = require('jsonld-request');
         break;
       default:
         throw new JsonLdError(
@@ -7229,9 +8188,9 @@ if(_nodejs) {
   };
 
   // expose version
-//  var _module = {exports: {}, filename: __dirname};
-//  require('pkginfo')(_module, 'version');
-//  jsonld.version = _module.exports.version;
+  /*var _module = {exports: {}, filename: __dirname};
+  require('pkginfo')(_module, 'version');
+  jsonld.version = _module.exports.version;*/
 }
 
 // end of jsonld API factory
@@ -7258,10 +8217,13 @@ if(!_nodejs && (typeof define === 'function' && define.amd)) {
   // wrap the main jsonld API instance
   wrapper(factory);
 
-  if(_nodejs) {
-    // export nodejs API
+  if(typeof require === 'function' &&
+    typeof module !== 'undefined' && module.exports) {
+    // export CommonJS/nodejs API
     module.exports = factory;
-  } else if(_browser) {
+  }
+
+  if(_browser) {
     // export simple browser API
     if(typeof jsonld === 'undefined') {
       jsonld = jsonldjs = factory;
@@ -7270,5 +8232,7 @@ if(!_nodejs && (typeof define === 'function' && define.amd)) {
     }
   }
 }
+
+return factory;
 
 })();

--- a/jsonld.js/src/main/scala/org/w3/banana/jsonldjs/JsonLdJs.scala
+++ b/jsonld.js/src/main/scala/org/w3/banana/jsonldjs/JsonLdJs.scala
@@ -3,6 +3,7 @@ package jsonldjs
 
 import scala.scalajs.js
 import scala.concurrent.{ Future, Promise }
+import scala.scalajs.js.annotation.{ JSGlobal }
 
 // the content of jsonldHelper should be in jsonld but it doesn't
 // work! Don't know why...
@@ -21,15 +22,14 @@ object jsonldHelper {
         } else {
           val triples =
             data.selectDynamic("@default")
-                .asInstanceOf[js.Array[js.Dictionary[js.Dictionary[String]]]]
+              .asInstanceOf[js.Array[js.Dictionary[js.Dictionary[String]]]]
           triples.foreach { (triple: js.Dictionary[js.Dictionary[String]]) =>
             mgraph += Triple.toBananaTriple(triple)
           }
           promise.success(mgraph.makeIGraph())
         }
         ()
-      }
-    )
+      })
     promise.future
   }
 
@@ -44,13 +44,13 @@ object jsonldHelper {
 }
 
 @js.native
+@JSGlobal
 object jsonld extends js.Object {
 
   def toRDF(
     doc: js.Dynamic,
     format: js.Dictionary[String],
-    callback: js.Function2[js.Error, js.Dynamic, Unit]
-  ): Unit = js.native
+    callback: js.Function2[js.Error, js.Dynamic, Unit]): Unit = js.native
 
 }
 
@@ -68,8 +68,7 @@ object Triple {
     ops.makeTriple(
       Node.toBananaNode(triple("subject")),
       ops.makeUri(triple("predicate")("value")),
-      Node.toBananaNode(triple("object"))
-    )
+      Node.toBananaNode(triple("object")))
   }
 
 }

--- a/jsonld.js/src/main/scala/org/w3/banana/jsonldjs/JsonLdJs.scala
+++ b/jsonld.js/src/main/scala/org/w3/banana/jsonldjs/JsonLdJs.scala
@@ -45,9 +45,9 @@ object jsonldHelper {
   }
 
   def fromRDFToDataset[Rdf <: RDF](_graph: Rdf#Graph)(implicit ops: RDFOps[Rdf]): js.Array[Dictionary[Dictionary[String]]] =
-    (for(triple <- ops.getTriples(_graph)) yield
+    (for (triple <- ops.getTriples(_graph)) yield
       Triple.fromBananaTriple(triple)
-    ).toSet.toJSArray
+      ).toSet.toJSArray
 
   def fromRDF[Rdf <: RDF](_graph: Rdf#Graph, base: String)(implicit ops: RDFOps[Rdf]): Future[js.Dynamic] = {
     val promise = Promise[js.Dynamic]()
@@ -60,12 +60,13 @@ object jsonldHelper {
         "base" -> base
       ),
       (err: js.Error, data: js.Dynamic) => {
-      if (err != null) {
-        promise.failure(ParsingError(err))
-      } else {
-       promise.success(data)
-      }
-    })
+        if (err != null) {
+          promise.failure(ParsingError(err))
+        } else {
+          promise.success(data)
+        }
+        ()
+      })
     promise.future
   }
 }
@@ -136,7 +137,7 @@ object Node {
           "type" -> "literal",
           "value" -> lexical,
           "datatype" -> datatype.toString
-        ) ++ lang.map( _lang => Map("lang" -> _lang.toString) ).getOrElse(Map.empty)
+        ) ++ lang.map(_lang => Map("lang" -> _lang.toString)).getOrElse(Map.empty)
     }
   }.toJSDictionary
 

--- a/jsonld.js/src/main/scala/org/w3/banana/jsonldjs/io/JsonLdJsParser.scala
+++ b/jsonld.js/src/main/scala/org/w3/banana/jsonldjs/io/JsonLdJsParser.scala
@@ -9,8 +9,7 @@ import scala.concurrent.{ Future, ExecutionContext }
 /** A JSON-LD parser for jsonld.js. */
 class JsonLdJsParser[Rdf <: RDF](implicit
   ops: RDFOps[Rdf],
-  ec: ExecutionContext
-) extends RDFReader[Rdf, Future, JsonLd] {
+  ec: ExecutionContext) extends RDFReader[Rdf, Future, JsonLd] {
 
   import ops._
 

--- a/jsonld.js/src/main/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializer.scala
+++ b/jsonld.js/src/main/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializer.scala
@@ -1,0 +1,34 @@
+package org.w3.banana.jsonldjs.io
+
+import java.io.{ByteArrayOutputStream, OutputStream}
+
+import org.w3.banana.io.{JsonLd, RDFWriter}
+import org.w3.banana.jsonldjs.jsonldHelper
+import org.w3.banana.{RDF, RDFOps}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.scalajs.js.JSON
+
+class JsonLdJsSerializer[Rdf <: RDF](implicit
+  ops: RDFOps[Rdf],
+  ec: ExecutionContext
+) extends RDFWriter[Rdf, Future, JsonLd] {
+
+
+  private val charSet = "UTF-8"
+
+  override def write(graph: Rdf#Graph, os: OutputStream, base: String): Future[Unit] = {
+    jsonldHelper.fromRDF(graph, base).map {
+      jsonld =>
+        os.write(JSON.stringify(jsonld).getBytes(charSet))
+    }
+  }
+
+  override def asString(graph: Rdf#Graph, base: String): Future[String] = {
+    val outputStream = new ByteArrayOutputStream()
+    write(graph, outputStream, base).map { _ =>
+      outputStream.toString(charSet)
+    }
+  }
+
+}

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/JsonLdJsTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/JsonLdJsTest.scala
@@ -1,13 +1,13 @@
 package org.w3.banana
 package jsonldjs
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scala.scalajs.js
 
 // the async stuff doesn't get properly tested by zcheck. Need to wait
 // for scala-js 0.6. Look for [error] in the output in the meantime...
-object JsonLdJsTest extends WordSpec with Matchers {
+class JsonLdJsTest extends WordSpec with Matchers {
 
   val input = """{
   "http://schema.org/name": "Manu Sporny",
@@ -28,22 +28,22 @@ object JsonLdJsTest extends WordSpec with Matchers {
 
   }
 
-//  @betehess: I was not able to get a (err != null)
-//  "parsejsonld.toRDF -- error" in {
-//
-//    val input = """{
-//  "http://schema.org/url": {"@foo": "baz"}
-//}"""
-//
-//    val doc = js.JSON.parse(input)
-//
-//    jsonld.toRDF(doc, js.Dictionary(), { (err: js.Error, data: js.Dynamic) =>
-//      check(err == null)
-//      check(data.selectDynamic("@default") != null)
-//      println(js.JSON.stringify(data))
-//      ()
-//    })
-//
-//  }
+  // @betehess: I was not able to get a (err != null)
+  /* "parsejsonld.toRDF -- error" in {
+
+    val input = """[
+  {"@context": {"@id": "@context"}}
+ ]"""
+
+    val doc = js.JSON.parse(input)
+
+    jsonld.toRDF(doc, js.Dictionary(), { (err: js.Error, data: js.Dynamic) =>
+      err shouldEqual null
+      data.selectDynamic("@default") should not be null
+      println(js.JSON.stringify(data))
+      ()
+    })
+
+  }*/
 
 }

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
@@ -2,13 +2,12 @@ package org.w3.banana
 package jsonldjs
 package io
 
-
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 import scalajs.concurrent.JSExecutionContext.Implicits.queue
 import org.w3.banana.plantain._
 
-object JsonLdJsParserTest extends WordSpec with Matchers {
+class JsonLdJsParserTest extends WordSpec with Matchers {
 
   import PlantainOps._
 
@@ -28,10 +27,9 @@ object JsonLdJsParserTest extends WordSpec with Matchers {
       import org.w3.banana.binder.ToURI.URIToURI
       val graph = (
         BNode()
-          -- schema("name") ->- "Manu Sporny"
-          -- schema("url") ->- URI("http://manu.sporny.org/")
-          -- schema("image") ->- URI("http://manu.sporny.org/images/manu.png")
-      ).graph
+        -- schema("name") ->- "Manu Sporny"
+        -- schema("url") ->- URI("http://manu.sporny.org/")
+        -- schema("image") ->- URI("http://manu.sporny.org/images/manu.png")).graph
 
       (g isIsomorphicWith graph) shouldEqual true
     }

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
@@ -5,12 +5,11 @@ package io
 import org.scalatest.{AsyncWordSpec, Matchers}
 import org.w3.banana.plantain._
 
-import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 class JsonLdJsParserTest extends AsyncWordSpec with Matchers {
 
   implicit override def executionContext =
-    scala.concurrent.ExecutionContext.Implicits.global
+   scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
   import PlantainOps._
 

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
@@ -6,8 +6,12 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 import org.w3.banana.plantain._
 
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+import scala.concurrent.ExecutionContext.Implicits.global
 
-object JsonLdJsParserTest extends AsyncWordSpec with Matchers {
+class JsonLdJsParserTest extends AsyncWordSpec with Matchers {
+
+  implicit override def executionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
 
   import PlantainOps._
 
@@ -15,7 +19,6 @@ object JsonLdJsParserTest extends AsyncWordSpec with Matchers {
   import org.w3.banana.binder.ToURI.URIToURI
 
   val parser = new JsonLdJsParser[Plantain]
-  val serializer = new JsonLdJsSerializer[Plantain]
 
   val schema = Prefix[Plantain]("schema", "http://schema.org/")
 
@@ -29,6 +32,7 @@ object JsonLdJsParserTest extends AsyncWordSpec with Matchers {
   "Simple parsing" in {
 
     val sr = new java.io.StringReader("""{
+  "@id": "http://www.example.org/Manu",
   "http://schema.org/name": "Manu Sporny",
   "http://schema.org/url": {"@id": "http://manu.sporny.org/"},
   "http://schema.org/image": {"@id": "http://manu.sporny.org/images/manu.png"}
@@ -36,7 +40,12 @@ object JsonLdJsParserTest extends AsyncWordSpec with Matchers {
 
     parser.read(sr, "http://example.com").map { g =>
 
-      (g isIsomorphicWith srGraph) shouldEqual true
+      //(g isIsomorphicWith srGraph) shouldEqual true
+      val subj = URI("http://www.example.org/Manu")
+
+      g.size shouldEqual 3
+      for(triple <- g.triples) println(triple.toString())
+      g.contains( Triple(subj, schema("name"), Literal("Manu Sporny")) ) shouldEqual true
     }
 
   }

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsParserTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 import org.w3.banana.plantain._
 
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class JsonLdJsParserTest extends AsyncWordSpec with Matchers {
 
@@ -23,7 +22,7 @@ class JsonLdJsParserTest extends AsyncWordSpec with Matchers {
   val schema = Prefix[Plantain]("schema", "http://schema.org/")
 
   val srGraph = (
-    BNode()
+    URI("http://www.example.org/Manu")
       -- schema("name") ->- "Manu Sporny"
       -- schema("url") ->- URI("http://manu.sporny.org/")
       -- schema("image") ->- URI("http://manu.sporny.org/images/manu.png")
@@ -40,12 +39,7 @@ class JsonLdJsParserTest extends AsyncWordSpec with Matchers {
 
     parser.read(sr, "http://example.com").map { g =>
 
-      //(g isIsomorphicWith srGraph) shouldEqual true
-      val subj = URI("http://www.example.org/Manu")
-
-      g.size shouldEqual 3
-      for(triple <- g.triples) println(triple.toString())
-      g.contains( Triple(subj, schema("name"), Literal("Manu Sporny")) ) shouldEqual true
+      (g isIsomorphicWith srGraph) shouldEqual true
     }
 
   }

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializationTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializationTest.scala
@@ -6,7 +6,10 @@ import org.w3.banana.plantain._
 
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-object JsonLdJsSerializationTest extends AsyncWordSpec with Matchers {
+class JsonLdJsSerializationTest extends AsyncWordSpec with Matchers {
+
+  implicit override def executionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
 
   import PlantainOps._
 
@@ -19,11 +22,13 @@ object JsonLdJsSerializationTest extends AsyncWordSpec with Matchers {
   val baseUri = "http://www.example.org"
 
   val srGraph = (
-    BNode()
+    URI("http://www.example.org/Manu")
       -- schema("name") ->- "Manu Sporny"
       -- schema("url") ->- URI("http://manu.sporny.org/")
       -- schema("image") ->- URI("http://manu.sporny.org/images/manu.png")
     ).graph
+
+  val jsonldRefString = """[{"@id":"http://www.example.org/Manu","http://schema.org/image":[{"@id":"http://manu.sporny.org/images/manu.png"}],"http://schema.org/url":[{"@id":"http://manu.sporny.org/"}],"http://schema.org/name":[{"@value":"Manu Sporny"}]}]"""
 
   "From Graph to JSONLd" in {
 
@@ -32,11 +37,7 @@ object JsonLdJsSerializationTest extends AsyncWordSpec with Matchers {
 
     fut.map { jsonldString =>
       println(jsonldString)
-      jsonldString shouldEqual """{
-"http://schema.org/name": "Manu Sporny",
-"http://schema.org/url": {"@id": "http://manu.sporny.org/"},
-"http://schema.org/image": {"@id": "http://manu.sporny.org/images/manu.png"}
-}"""
+      jsonldString shouldEqual jsonldRefString
     }
 
   }

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializationTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializationTest.scala
@@ -1,23 +1,22 @@
-package org.w3.banana
-package jsonldjs
-package io
+package org.w3.banana.jsonldjs.io
 
 import org.scalatest.{AsyncWordSpec, Matchers}
+import org.w3.banana.Prefix
 import org.w3.banana.plantain._
 
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
-object JsonLdJsParserTest extends AsyncWordSpec with Matchers {
+object JsonLdJsSerializationTest extends AsyncWordSpec with Matchers {
 
   import PlantainOps._
 
   // TODO why can't we get rid of that implicit?
   import org.w3.banana.binder.ToURI.URIToURI
 
-  val parser = new JsonLdJsParser[Plantain]
   val serializer = new JsonLdJsSerializer[Plantain]
 
   val schema = Prefix[Plantain]("schema", "http://schema.org/")
+  val baseUri = "http://www.example.org"
 
   val srGraph = (
     BNode()
@@ -26,17 +25,18 @@ object JsonLdJsParserTest extends AsyncWordSpec with Matchers {
       -- schema("image") ->- URI("http://manu.sporny.org/images/manu.png")
     ).graph
 
-  "Simple parsing" in {
+  "From Graph to JSONLd" in {
 
-    val sr = new java.io.StringReader("""{
-  "http://schema.org/name": "Manu Sporny",
-  "http://schema.org/url": {"@id": "http://manu.sporny.org/"},
-  "http://schema.org/image": {"@id": "http://manu.sporny.org/images/manu.png"}
-}""")
+    val fut = serializer.asString(srGraph, baseUri)
+    //fut shouldBe defined
 
-    parser.read(sr, "http://example.com").map { g =>
-
-      (g isIsomorphicWith srGraph) shouldEqual true
+    fut.map { jsonldString =>
+      println(jsonldString)
+      jsonldString shouldEqual """{
+"http://schema.org/name": "Manu Sporny",
+"http://schema.org/url": {"@id": "http://manu.sporny.org/"},
+"http://schema.org/image": {"@id": "http://manu.sporny.org/images/manu.png"}
+}"""
     }
 
   }

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializationTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializationTest.scala
@@ -4,12 +4,11 @@ import org.scalatest.{AsyncWordSpec, Matchers}
 import org.w3.banana.Prefix
 import org.w3.banana.plantain._
 
-import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
 class JsonLdJsSerializationTest extends AsyncWordSpec with Matchers {
 
   implicit override def executionContext =
-    scala.concurrent.ExecutionContext.Implicits.global
+    scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 
   import PlantainOps._
 

--- a/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializationTest.scala
+++ b/jsonld.js/src/test/scala/org/w3/banana/jsonldjs/io/JsonLdJsSerializationTest.scala
@@ -36,7 +36,6 @@ class JsonLdJsSerializationTest extends AsyncWordSpec with Matchers {
     //fut shouldBe defined
 
     fut.map { jsonldString =>
-      println(jsonldString)
       jsonldString shouldEqual jsonldRefString
     }
 

--- a/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
+++ b/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
@@ -54,7 +54,7 @@ trait IOExample extends IOExampleDependencies {
     val graphAsXMLString = rdfXMLWriter.asString(graph10Triples, base = timblCard) getOrElse sys.error("coudn't serialize the graph")
     println(graphAsXMLString)
 
-    val graphAsTurtleString = turtleWriter.asString(graph10Triples, base = timblCard, foaf, rdf) getOrElse sys.error("coudn't serialize the graph")
+    val graphAsTurtleString = turtleWriter.asString(graph10Triples, base = timblCard, Set(foaf, rdf)) getOrElse sys.error("coudn't serialize the graph")
     println(graphAsTurtleString)
   }
 

--- a/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
+++ b/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
@@ -10,6 +10,7 @@ trait IOExampleDependencies
   extends RDFModule
   with RDFOpsModule
   with TurtleReaderModule
+  with TurtleWriterModule
   with RDFXMLWriterModule
 
 /* Here is an example doing some IO. Read below to see what's
@@ -45,11 +46,16 @@ trait IOExample extends IOExampleDependencies {
     if (ret.isSuccess)
       println(s"successfuly wrote TimBL's card to ${tmpFile.getAbsolutePath}")
 
+    val foaf = FOAFPrefix[Rdf]
+    val rdf = RDFSPrefix[Rdf]
     /* prints 10 triples to stdout */
 
     val graph10Triples = Graph(graph.triples.take(10).toSet)
-    val graphAsString = rdfXMLWriter.asString(graph10Triples, base = timblCard) getOrElse sys.error("coudn't serialize the graph")
-    println(graphAsString)
+    val graphAsXMLString = rdfXMLWriter.asString(graph10Triples, base = timblCard) getOrElse sys.error("coudn't serialize the graph")
+    println(graphAsXMLString)
+
+    val graphAsTurtleString = turtleWriter.asString(graph10Triples, base = timblCard, foaf, rdf) getOrElse sys.error("coudn't serialize the graph")
+    println(graphAsTurtleString)
   }
 
 }

--- a/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
+++ b/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
@@ -2,7 +2,7 @@ package org.w3.banana.io
 
 import java.io.OutputStream
 
-import org.w3.banana.{RDF, RDFOps}
+import org.w3.banana.{Prefix, RDF, RDFOps}
 
 import scala.util.Try
 
@@ -33,14 +33,14 @@ class NTriplesWriter[Rdf <: RDF](implicit val ops:RDFOps[Rdf]) extends RDFWriter
     }
   )
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Prefix[Rdf]*): Try[Unit] = Try {
     for (triple <- graph.triples) {
       val line = tripleAsString(triple) + "\r\n"
       os.write(line.getBytes("UTF-8"))
     }
   }
 
-  def asString(graph: Rdf#Graph, base: String): Try[String] = Try{
+  def asString(graph: Rdf#Graph, base: String, prefixes: Prefix[Rdf]*): Try[String] = Try{
     (
       for ( triple <- ops.getTriples(graph))
       yield tripleAsString(triple)

--- a/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
+++ b/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
@@ -33,14 +33,14 @@ class NTriplesWriter[Rdf <: RDF](implicit val ops:RDFOps[Rdf]) extends RDFWriter
     }
   )
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Prefix[Rdf]*): Try[Unit] = Try {
+  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Rdf]]): Try[Unit] = Try {
     for (triple <- graph.triples) {
       val line = tripleAsString(triple) + "\r\n"
       os.write(line.getBytes("UTF-8"))
     }
   }
 
-  def asString(graph: Rdf#Graph, base: String, prefixes: Prefix[Rdf]*): Try[String] = Try{
+  def asString(graph: Rdf#Graph, base: String, prefixes: Set[Prefix[Rdf]]): Try[String] = Try{
     (
       for ( triple <- ops.getTriples(graph))
       yield tripleAsString(triple)

--- a/plantain/js/src/main/scala/org/w3/banana/plantain/Plantain.scala
+++ b/plantain/js/src/main/scala/org/w3/banana/plantain/Plantain.scala
@@ -8,7 +8,7 @@ import java.net.URI
 trait Plantain extends RDF {
 
   // types related to the RDF datamodel
-  type Graph = model.Graph[Node, URI, Node]
+  type Graph = model.IntHexastoreGraph[Node, URI, Node]
   type Triple = (Node, URI, Node)
   type Node = Any
   type URI = java.net.URI

--- a/plantain/js/src/main/scala/org/w3/banana/plantain/PlantainMGraphOps.scala
+++ b/plantain/js/src/main/scala/org/w3/banana/plantain/PlantainMGraphOps.scala
@@ -6,7 +6,7 @@ trait PlantainMGraphOps extends MGraphOps[Plantain] {
 
   def makeMGraph(graph: Plantain#Graph): Plantain#MGraph = new model.MGraph(graph)
 
-  def makeEmptyMGraph(): Plantain#MGraph = new model.MGraph(model.Graph.empty)
+  def makeEmptyMGraph(): Plantain#MGraph = new model.MGraph(model.IntHexastoreGraph.empty)
 
   def addTriple(mgraph: Plantain#MGraph, triple: Plantain#Triple): mgraph.type = {
     val (s, p, o) = triple

--- a/plantain/js/src/main/scala/org/w3/banana/plantain/PlantainOps.scala
+++ b/plantain/js/src/main/scala/org/w3/banana/plantain/PlantainOps.scala
@@ -9,7 +9,7 @@ object PlantainOps extends RDFOps[Plantain] with PlantainMGraphOps with Plantain
 
   // graph
 
-  final val emptyGraph: Plantain#Graph = model.Graph(Map.empty, 0)
+  final val emptyGraph: Plantain#Graph = model.IntHexastoreGraph.empty
 
   final def makeGraph(triples: Iterable[Plantain#Triple]): Plantain#Graph =
     triples.foldLeft(emptyGraph) { case (g, (s, p, o)) => g + (s, p, o) }

--- a/plantain/js/src/main/scala/org/w3/banana/plantain/model/model.scala
+++ b/plantain/js/src/main/scala/org/w3/banana/plantain/model/model.scala
@@ -3,7 +3,7 @@ package org.w3.banana.plantain.model
 import org.w3.banana._
 import java.net.URI
 
-final class MGraph[S, P, O](var graph: Graph[S, P, O])
+final class MGraph[S, P, O](var graph: IntHexastoreGraph[S, P, O])
 
 final case class BNode(label: String)
 

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/Plantain.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/Plantain.scala
@@ -8,7 +8,7 @@ import org.w3.banana._
 trait Plantain extends RDF {
 
   // types related to the RDF datamodel
-  type Graph = model.Graph[Node, URI, Node]
+  type Graph = model.IntHexastoreGraph[Node, URI, Node]
   type Triple = (Node, URI, Node)
   type Node = Any
   type URI = Uri

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainMGraphOps.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainMGraphOps.scala
@@ -6,7 +6,7 @@ trait PlantainMGraphOps extends MGraphOps[Plantain] {
 
   def makeMGraph(graph: Plantain#Graph): Plantain#MGraph = new model.MGraph(graph)
 
-  def makeEmptyMGraph(): Plantain#MGraph = new model.MGraph(model.Graph.empty)
+  def makeEmptyMGraph(): Plantain#MGraph = new model.MGraph(model.IntHexastoreGraph.empty[Plantain#Node, Plantain#URI, Plantain#Node])
 
   def addTriple(mgraph: Plantain#MGraph, triple: Plantain#Triple): mgraph.type = {
     val (s, p, o) = triple

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainOps.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainOps.scala
@@ -10,7 +10,7 @@ object PlantainOps extends RDFOps[Plantain] with PlantainMGraphOps with Plantain
 
   // graph
 
-  final val emptyGraph: Plantain#Graph = model.Graph(Map.empty, 0)
+  final val emptyGraph: Plantain#Graph = model.IntHexastoreGraph.empty[Plantain#Node, Plantain#URI, Plantain#Node]
 
   final def makeGraph(triples: Iterable[Plantain#Triple]): Plantain#Graph =
     triples.foldLeft(emptyGraph) { case (g, (s, p, o)) => g + (s, p, o) }

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
@@ -54,12 +54,9 @@ object PlantainTurtleWriter extends RDFWriter[Plantain, Try, Turtle] {
     def write(): Try[Unit] = Try {
       val writer = new TurtleWriter(outputstream)
       writer.startRDF()
-      graph.spo foreach { case (s, pos) =>
-        pos foreach { case (p, os) =>
-          os foreach { o =>
-            writer.handleStatement(statement(s, p, o))
-          }
-        }
+      graph.triples foreach {
+        case (s, p, o) =>
+          writer.handleStatement(statement(s, p, o))
       }
       writer.endRDF()
     }

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
@@ -6,6 +6,7 @@ import java.net.{URI => jURI}
 import org.openrdf.model.impl._
 import org.openrdf.rio.turtle._
 import org.openrdf.{model => sesame}
+import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.plantain._
 
@@ -63,12 +64,12 @@ object PlantainTurtleWriter extends RDFWriter[Plantain, Try, Turtle] {
 
   }
 
-  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String): Try[Unit] = {
+  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String, prefixes: Prefix[Plantain]*): Try[Unit] = {
     val writer = new Writer(graph, outputstream, base)
     writer.write()
   }
 
-  def asString(graph: Plantain#Graph, base: String): Try[String] = Try {
+  def asString(graph: Plantain#Graph, base: String, prefixes: Prefix[Plantain]*): Try[String] = Try {
     val result = new ByteArrayOutputStream()
     val writer = new Writer(graph, result, base)
     writer.write()

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
@@ -64,12 +64,12 @@ object PlantainTurtleWriter extends RDFWriter[Plantain, Try, Turtle] {
 
   }
 
-  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String, prefixes: Prefix[Plantain]*): Try[Unit] = {
+  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String, prefixes: Set[Prefix[Plantain]]): Try[Unit] = {
     val writer = new Writer(graph, outputstream, base)
     writer.write()
   }
 
-  def asString(graph: Plantain#Graph, base: String, prefixes: Prefix[Plantain]*): Try[String] = Try {
+  def asString(graph: Plantain#Graph, base: String, prefixes: Set[Prefix[Plantain]]): Try[String] = Try {
     val result = new ByteArrayOutputStream()
     val writer = new Writer(graph, result, base)
     writer.write()

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/model/model.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/model/model.scala
@@ -2,7 +2,7 @@ package org.w3.banana.plantain.model
 
 import akka.http.scaladsl.model.Uri
 
-final class MGraph[S, P, O](var graph: Graph[S, P, O])
+final class MGraph[S, P, O](var graph: IntHexastoreGraph[S, P, O])
 
 final case class BNode(label: String)
 

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/HexastoreGraph.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/HexastoreGraph.scala
@@ -129,38 +129,6 @@ case class HexastoreTriples[T](
                                 ops: HexastoreMap[T]
                               )
 
-trait SPODictionaries[T, S, P, O] {
-
-  def subjectOf(s: T): S
-
-  def objectOf(o: T): O
-
-  def predicateOf(p: T): P
-
-  def removeSubjectKey(s: T): SPODictionaries[T, S, P, O]
-
-  def removePredicateKey(p: T): SPODictionaries[T, S, P, O]
-
-  def removeObjectKey(o: T): SPODictionaries[T, S, P, O]
-
-  def tripleOf(triple: (T, T, T)): (S, P, O) = (subjectOf(triple._1), predicateOf(triple._2), objectOf(triple._3))
-
-  def fromSubject(s: S): T
-
-  def fromObject(o: O): T
-
-  def fromPredicate(p: P): T
-
-  def hasSubject(s: S): Boolean
-
-  def hasObject(o: O): Boolean
-
-  def hasPredicate(p: P): Boolean
-
-  def newFromTriple(s: S, p: P, o: O): (T, T, T, SPODictionaries[T, S, P, O])
-
-
-}
 
 trait HexastoreGraph[T, S, P, O] {
 
@@ -168,7 +136,7 @@ trait HexastoreGraph[T, S, P, O] {
 
   def hexaTriples: HexastoreTriples[T]
 
-  def dicts: SPODictionaries[T, S, P, O]
+  def dicts: SPODictionary[T, S, P, O]
 
 
   def triples: Iterable[(S, P, O)] =
@@ -248,7 +216,7 @@ trait HexastoreGraph[T, S, P, O] {
     matchedTriples.foldLeft(this) { case (graph, (_s, _p, _o)) => graph - (_s, _p, _o) }
   }
 
-  def newHexastoreGraph(_hexaTriples: HexastoreTriples[T], _dicts: SPODictionaries[T, S, P, O], size: Int): HexastoreGraph[T, S, P, O]
+  def newHexastoreGraph(_hexaTriples: HexastoreTriples[T], _dicts: SPODictionary[T, S, P, O], size: Int): HexastoreGraph[T, S, P, O]
 
 
   def union(other: HexastoreGraph[T, S, P, O]): HexastoreGraph[T, S, P, O] = {

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/HexastoreGraph.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/HexastoreGraph.scala
@@ -1,0 +1,295 @@
+package org.w3.banana.plantain.model
+
+import scala.collection.immutable
+import scala.util.Try
+
+object HexastoreMap {
+
+  def empty[T]: HexastoreMap[T] = HexastoreMap(immutable.HashMap.empty[T, immutable.HashMap[T, immutable.List[T]]])
+}
+
+case class HexastoreMap[T](map: immutable.HashMap[T, immutable.HashMap[T, immutable.List[T]]]) {
+  def +(a: T, b: T, c: T): HexastoreMap[T] = {
+    val newMap = map.get(a) match {
+      case Some(_bMap) =>
+        _bMap.get(b) match {
+          case Some(_cList) =>
+            if (_cList.contains(c)) {
+              map
+            } else {
+              map + (a -> (_bMap + (b -> (_cList :+ c))))
+            }
+          case None =>
+            map + (a -> (_bMap + (b -> immutable.List(c))))
+        }
+      case None =>
+        map + (a -> immutable.HashMap(b -> immutable.List(c)))
+    }
+    HexastoreMap(newMap)
+  }
+
+  def -(a: T, b: T, c: T): HexastoreMap[T] = {
+    val newMap = map.get(a) match {
+      case Some(_bMap) =>
+        _bMap.get(b) match {
+          case Some(_cList) =>
+            if (_cList.contains(c)) {
+              val newCList = _cList.filter(_ == c)
+              if (newCList.nonEmpty) {
+                map + (a -> (_bMap + (b -> newCList)))
+              } else {
+                val newBMap = _bMap - b
+                if (newBMap.nonEmpty) {
+                  map + (a -> newBMap)
+                } else {
+                  map - a
+                }
+              }
+            } else {
+              //no such element
+              map
+            }
+          case None =>
+            //no such element
+            map
+        }
+      case None =>
+        //no such element
+        map
+    }
+    HexastoreMap(newMap)
+
+  }
+
+  def contains(a: T, b: T, c: T): Boolean = {
+    map.get(a)
+      .flatMap(_.get(b)).exists(_.contains(c))
+
+  }
+
+  def ab(a: T, b: T): Iterable[(T, T, T)] = {
+    val test = map.get(a)
+      .flatMap { bMap =>
+        bMap.get(b)
+      }
+
+    test.map { cList =>
+      cList.map(c => (a, b, c))
+    }
+      .getOrElse(Iterable.empty)
+  }
+
+  def a(a: T): Iterable[(T, T, T)] = {
+    map.get(a)
+      .map { bMap =>
+        bMap.flatMap { b =>
+          b._2.map(c => (a, b._1, c))
+        }
+      }
+      .getOrElse(Iterable.empty)
+  }
+
+
+}
+
+object HexastoreTriples {
+
+  def empty[T]: HexastoreTriples[T] = HexastoreTriples(
+    HexastoreMap.empty[T],
+    HexastoreMap.empty[T],
+    HexastoreMap.empty[T],
+    HexastoreMap.empty[T],
+    HexastoreMap.empty[T],
+    HexastoreMap.empty[T]
+  )
+
+}
+
+case class HexastoreTriples[T](
+                                spo: HexastoreMap[T],
+                                sop: HexastoreMap[T],
+                                pso: HexastoreMap[T],
+                                pos: HexastoreMap[T],
+                                osp: HexastoreMap[T],
+                                ops: HexastoreMap[T]
+                              )
+
+trait SPODictionaries[T, S, P, O] {
+
+  def subjectOf(s: T): S
+
+  def objectOf(o: T): O
+
+  def predicateOf(p: T): P
+
+  def removeFromSubjects(s: S): SPODictionaries[T, S, P, O]
+
+  def removeFromPredicates(p: P): SPODictionaries[T, S, P, O]
+
+  def removeFromObjects(o: O): SPODictionaries[T, S, P, O]
+
+  def tripleOf(triple: (T, T, T)): (S, P, O) = (subjectOf(triple._1), predicateOf(triple._2), objectOf(triple._3))
+
+  def fromSubject(s: S): T
+
+  def fromObject(o: O): T
+
+  def fromPredicate(p: P): T
+
+  def hasSubject(s: S): Boolean
+
+  def hasObject(o: O): Boolean
+
+  def hasPredicate(p: P): Boolean
+
+  def newFromTriple(s: S, p: P, o: O): (T, T, T, SPODictionaries[T, S, P, O])
+
+
+}
+
+trait HexastoreGraph[T, S, P, O] {
+
+  def size: Int
+
+  def hexaTriples: HexastoreTriples[T]
+
+  def dicts: SPODictionaries[T, S, P, O]
+
+
+  def triples: Iterable[(S, P, O)] =
+    for {
+      (s, poMap) <- hexaTriples.spo.map
+      (p, oList) <- poMap
+      o <- oList
+    } yield (dicts.subjectOf(s), dicts.predicateOf(p), dicts.objectOf(o))
+
+
+  def +(subject: S, predicate: P, objectt: O): HexastoreGraph[T, S, P, O] = {
+    val (s, p, o, newDict) = dicts.newFromTriple(subject, predicate, objectt)
+    val (
+      spo,
+      sop,
+      pso,
+      pos,
+      osp,
+      ops) = HexastoreTriples.unapply(hexaTriples).get
+
+    newHexastoreGraph(
+      HexastoreTriples(
+        spo + (s, p, o),
+        sop + (s, o, p),
+        pso + (p, s, o),
+        pos + (p, o, s),
+        osp + (o, s, p),
+        ops + (o, p, s)),
+      newDict,
+      size + 1
+    )
+
+  }
+
+  def -(subject: S, predicate: P, objectt: O): HexastoreGraph[T, S, P, O] = {
+    val s = dicts.fromSubject(subject)
+    val p = dicts.fromPredicate(predicate)
+    val o = dicts.fromObject(objectt)
+    val (
+      spo,
+      sop,
+      pso,
+      pos,
+      osp,
+      ops) = HexastoreTriples.unapply(hexaTriples).get
+
+
+    val newHexastoreTriples =
+      HexastoreTriples(
+        spo - (s, p, o),
+        sop - (s, o, p),
+        pso - (p, s, o),
+        pos - (p, o, s),
+        osp - (o, s, p),
+        ops - (o, p, s))
+
+    //TODO: do something about ever growing dictionaries (complete rebuild?)
+
+    var newDicts = dicts
+    if(!newHexastoreTriples.spo.map.contains(s))
+      newDicts = newDicts.removeFromSubjects(subject)
+    if(!newHexastoreTriples.pos.map.contains(p))
+      newDicts = newDicts.removeFromPredicates(predicate)
+    if(!newHexastoreTriples.osp.map.contains(o))
+      newDicts = newDicts.removeFromObjects(objectt)
+
+    newHexastoreGraph(
+      newHexastoreTriples,
+      newDicts,
+      size - 1
+    )
+
+  }
+
+  def -(s: Option[S], p: Option[P], o: Option[O]): HexastoreGraph[T, S, P, O] = {
+    val matchedTriples: Iterable[(S, P, O)] = find(s, p, o)
+    matchedTriples.foldLeft(this) { case (graph, (_s, _p, _o)) => graph - (_s, _p, _o) }
+  }
+
+  def newHexastoreGraph(_hexaTriples: HexastoreTriples[T], _dicts: SPODictionaries[T, S, P, O], size: Int): HexastoreGraph[T, S, P, O]
+
+
+  def union(other: HexastoreGraph[T, S, P, O]): HexastoreGraph[T, S, P, O] = {
+    val (firstGraph, secondGraph) =
+      if (this.size > other.size) (this, other)
+      else (other, this)
+    secondGraph.triples.foldLeft(firstGraph) { case (graph, (s, p, o)) => graph + (s, p, o) }
+  }
+
+  def find(subject: Option[S], predicate: Option[P], objectt: Option[O]): Iterable[(S, P, O)] = {
+
+    if (!(subject.map(dicts.hasSubject(_)).getOrElse(true) &&
+      predicate.map(dicts.hasPredicate(_)).getOrElse(true) &&
+      objectt.map(dicts.hasObject(_)).getOrElse(true))) {
+      return Iterable.empty
+    }
+    val (_subject, _predicate, _object) = (subject.map(dicts.fromSubject(_)), predicate.map(dicts.fromPredicate(_)), objectt.map(dicts.fromObject(_)))
+    val (
+      spo,
+      sop,
+      pso,
+      pos,
+      osp,
+      ops) = HexastoreTriples.unapply(hexaTriples).get
+
+    (_subject, _predicate, _object) match {
+
+      case (None, None, None) => triples
+      case (Some(s), Some(p), Some(o)) => {
+        if (hexaTriples.spo.contains(s, p, o)) {
+          Iterable((dicts.subjectOf(s), dicts.predicateOf(p), dicts.objectOf(o)))
+        } else {
+          Iterable.empty
+        }
+      }
+      case (Some(s), Some(p), None) =>
+        spo.ab(s, p).map(dicts.tripleOf)
+      case (Some(s), None, Some(o)) =>
+        sop.ab(s, o).map(tr => dicts.tripleOf(tr._1, tr._3, tr._2))
+      case (None, Some(p), Some(o)) =>
+        pos.ab(p, o).map(tr => dicts.tripleOf(tr._3, tr._1, tr._2))
+      case (Some(s), None, None) =>
+        spo.a(s).map(dicts.tripleOf)
+      case (None, Some(p), None) =>
+        pso.a(p).map(tr => dicts.tripleOf(tr._2, tr._1, tr._3))
+      case (None, None, Some(o)) =>
+        ops.a(o).map(tr => dicts.tripleOf(tr._3, tr._2, tr._1))
+    }
+  }
+
+  override def toString(): String = triples.mkString("(", " ", ")")
+
+}
+
+object HexastoreGraph {
+
+  // def apply[T, S, P, O](_hexaTriples: HexastoreTriples[T], _dicts: SPODictionaries[T,S,P,O]): HexastoreGraph[T,S,P,O]
+
+}

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/HexastoreGraph.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/HexastoreGraph.scala
@@ -1,12 +1,6 @@
 package org.w3.banana.plantain.model
 
 import scala.collection.immutable
-import scala.util.Try
-
-object HexastoreMap {
-
-  def empty[T]: HexastoreMap[T] = HexastoreMap(immutable.HashMap.empty[T, immutable.HashMap[T, immutable.List[T]]])
-}
 
 trait HexastoreStruct[T] extends Iterable[(T,T,T)] {
 
@@ -119,6 +113,20 @@ case class HexastoreMap[T](tripleKeyMap: immutable.HashMap[T, immutable.HashMap[
 
 }
 
+object HexastoreMap {
+
+  def empty[T]: HexastoreMap[T] = HexastoreMap(immutable.HashMap.empty[T, immutable.HashMap[T, immutable.List[T]]])
+}
+
+case class HexastoreTriples[T](
+                                spo: HexastoreStruct[T],
+                                sop: HexastoreStruct[T],
+                                pso: HexastoreStruct[T],
+                                pos: HexastoreStruct[T],
+                                osp: HexastoreStruct[T],
+                                ops: HexastoreStruct[T]
+                              )
+
 object HexastoreTriples {
 
   def empty[T]: HexastoreTriples[T] = HexastoreTriples(
@@ -131,16 +139,6 @@ object HexastoreTriples {
   )
 
 }
-
-case class HexastoreTriples[T](
-                                spo: HexastoreStruct[T],
-                                sop: HexastoreStruct[T],
-                                pso: HexastoreStruct[T],
-                                pos: HexastoreStruct[T],
-                                osp: HexastoreStruct[T],
-                                ops: HexastoreStruct[T]
-                              )
-
 
 trait HexastoreGraph[T, S, P, O] {
 

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/HexastoreGraph.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/HexastoreGraph.scala
@@ -8,7 +8,22 @@ object HexastoreMap {
   def empty[T]: HexastoreMap[T] = HexastoreMap(immutable.HashMap.empty[T, immutable.HashMap[T, immutable.List[T]]])
 }
 
-case class HexastoreMap[T](map: immutable.HashMap[T, immutable.HashMap[T, immutable.List[T]]]) {
+trait HexastoreStruct[T] {
+
+  def +(a: T, b: T, c: T): HexastoreStruct[T]
+
+  def -(a: T, b: T, c: T): HexastoreStruct[T]
+
+  def contains(a: T, b: T, c: T): Boolean
+
+  def ab(a: T, b: T): Iterable[(T, T, T)]
+
+  def a(a: T): Iterable[(T, T, T)]
+
+}
+
+case class HexastoreMap[T](map: immutable.HashMap[T, immutable.HashMap[T, immutable.List[T]]]) extends HexastoreStruct[T] {
+
   def +(a: T, b: T, c: T): HexastoreMap[T] = {
     val newMap = map.get(a) match {
       case Some(_bMap) =>
@@ -122,11 +137,11 @@ trait SPODictionaries[T, S, P, O] {
 
   def predicateOf(p: T): P
 
-  def removeFromSubjects(s: S): SPODictionaries[T, S, P, O]
+  def removeSubjectKey(s: T): SPODictionaries[T, S, P, O]
 
-  def removeFromPredicates(p: P): SPODictionaries[T, S, P, O]
+  def removePredicateKey(p: T): SPODictionaries[T, S, P, O]
 
-  def removeFromObjects(o: O): SPODictionaries[T, S, P, O]
+  def removeObjectKey(o: T): SPODictionaries[T, S, P, O]
 
   def tripleOf(triple: (T, T, T)): (S, P, O) = (subjectOf(triple._1), predicateOf(triple._2), objectOf(triple._3))
 
@@ -214,11 +229,11 @@ trait HexastoreGraph[T, S, P, O] {
 
     var newDicts = dicts
     if(!newHexastoreTriples.spo.map.contains(s))
-      newDicts = newDicts.removeFromSubjects(subject)
+      newDicts = newDicts.removeSubjectKey(s)
     if(!newHexastoreTriples.pos.map.contains(p))
-      newDicts = newDicts.removeFromPredicates(predicate)
+      newDicts = newDicts.removePredicateKey(p)
     if(!newHexastoreTriples.osp.map.contains(o))
-      newDicts = newDicts.removeFromObjects(objectt)
+      newDicts = newDicts.removeObjectKey(o)
 
     newHexastoreGraph(
       newHexastoreTriples,
@@ -288,8 +303,3 @@ trait HexastoreGraph[T, S, P, O] {
 
 }
 
-object HexastoreGraph {
-
-  // def apply[T, S, P, O](_hexaTriples: HexastoreTriples[T], _dicts: SPODictionaries[T,S,P,O]): HexastoreGraph[T,S,P,O]
-
-}

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntHexastoreGraph.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntHexastoreGraph.scala
@@ -1,7 +1,7 @@
 package org.w3.banana.plantain.model
 
 
-case class IntHexastoreGraph[S, P, O](hexaTriples: HexastoreTriples[Int], dicts: SPODictionaries[Int, S, P, O], size: Int) extends HexastoreGraph[Int, S, P, O] {
+case class IntHexastoreGraph[S, P, O](hexaTriples: HexastoreTriples[Int], dicts: SPODictionary[Int, S, P, O], size: Int) extends HexastoreGraph[Int, S, P, O] {
   //override def size: Int = _size
 
   //override def hexaTriples: HexastoreTriples[Int] = _hexaTriples
@@ -12,7 +12,7 @@ case class IntHexastoreGraph[S, P, O](hexaTriples: HexastoreTriples[Int], dicts:
 
   override def +(subject: S, predicate: P, objectt: O): IntHexastoreGraph[S, P, O] = super.+(subject, predicate, objectt).asInstanceOf[IntHexastoreGraph[S, P, O]]
 
-  override def newHexastoreGraph(_hexaTriples: HexastoreTriples[Int], _dicts: SPODictionaries[Int, S, P, O], _size: Int): HexastoreGraph[Int, S, P, O] =
+  override def newHexastoreGraph(_hexaTriples: HexastoreTriples[Int], _dicts: SPODictionary[Int, S, P, O], _size: Int): HexastoreGraph[Int, S, P, O] =
     new IntHexastoreGraph[S, P, O](_hexaTriples, _dicts, _size)
 
 }
@@ -20,6 +20,6 @@ case class IntHexastoreGraph[S, P, O](hexaTriples: HexastoreTriples[Int], dicts:
 
 object IntHexastoreGraph {
 
-  def empty[S, P, O]: IntHexastoreGraph[S, P, O] = IntHexastoreGraph[S, P, O](HexastoreTriples.empty[Int], IntBTreeSPODictionaries.empty[S, P, O], 0)
+  def empty[S, P, O]: IntHexastoreGraph[S, P, O] = IntHexastoreGraph[S, P, O](HexastoreTriples.empty[Int], IntSPODictionary.empty[S, P, O], 0)
 
 }

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntHexastoreGraph.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntHexastoreGraph.scala
@@ -1,92 +1,5 @@
 package org.w3.banana.plantain.model
 
-class IntSPODictionary[S, P, O](
-                                 subjectMap: Map[Int, S],
-                                 predicateMap: Map[Int, P],
-                                 objectMap: Map[Int, O],
-                                 rsubjectMap: Map[S, Int],
-                                 rpredicateMap: Map[P, Int],
-                                 robjectMap: Map[O, Int],
-                                 counter: Int
-                               ) extends SPODictionaries[Int, S, P, O] {
-
-
-  override def subjectOf(s: Int): S = subjectMap(s)
-
-  override def objectOf(o: Int): O = objectMap(o)
-
-  override def predicateOf(p: Int): P = predicateMap(p)
-
-  override def fromSubject(s: S): Int = rsubjectMap(s)
-
-  override def fromObject(o: O): Int = robjectMap(o)
-
-  override def fromPredicate(p: P): Int = rpredicateMap(p)
-
-  override def hasSubject(s: S): Boolean = rsubjectMap.contains(s)
-
-  override def hasObject(o: O): Boolean = robjectMap.contains(o)
-
-  override def hasPredicate(p: P): Boolean = rpredicateMap.contains(p)
-
-  override def newFromTriple(s: S, p: P, o: O): (Int, Int, Int, SPODictionaries[Int, S, P, O]) = {
-    var newCounter = counter
-    val subj = rsubjectMap.get(s) match {
-      case Some(num) => (num, subjectMap, rsubjectMap)
-      case _ => newCounter = newCounter + 1
-        (newCounter, subjectMap + (newCounter -> s), rsubjectMap + (s -> newCounter))
-    }
-    val pred = rpredicateMap.get(p) match {
-      case Some(num) => (num, predicateMap, rpredicateMap)
-      case _ => newCounter = newCounter + 1
-        (newCounter, predicateMap + (newCounter -> p), rpredicateMap + (p -> newCounter))
-    }
-    val obj = robjectMap.get(o) match {
-      case Some(num) => (num, objectMap, robjectMap)
-      case _ => newCounter = newCounter + 1
-        (newCounter, objectMap + (newCounter -> o), robjectMap + (o -> newCounter))
-    }
-    (subj._1, pred._1, obj._1, new IntSPODictionary(
-      subj._2, pred._2, obj._2,
-      subj._3, pred._3, obj._3,
-      newCounter
-    ))
-
-
-  }
-
-  override def removeFromSubjects(s: S): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
-    subjectMap - fromSubject(s), predicateMap, objectMap,
-    rsubjectMap - s, rpredicateMap, robjectMap,
-    counter
-  )
-
-  override def removeFromPredicates(p: P): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
-    subjectMap, predicateMap - fromPredicate(p), objectMap,
-    rsubjectMap, rpredicateMap - p, robjectMap,
-    counter
-  )
-
-  override def removeFromObjects(o: O): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
-    subjectMap, predicateMap, objectMap - fromObject(o),
-    rsubjectMap, rpredicateMap, robjectMap - o,
-    counter
-  )
-}
-
-object IntSPODictionary {
-
-  def empty[S, P, O]: IntSPODictionary[S, P, O] = new IntSPODictionary[S, P, O](
-    Map.empty[Int, S],
-    Map.empty[Int, P],
-    Map.empty[Int, O],
-    Map.empty[S, Int],
-    Map.empty[P, Int],
-    Map.empty[O, Int],
-    0
-  )
-
-}
 
 case class IntHexastoreGraph[S, P, O](hexaTriples: HexastoreTriples[Int], dicts: SPODictionaries[Int, S, P, O], size: Int) extends HexastoreGraph[Int, S, P, O] {
   //override def size: Int = _size
@@ -107,6 +20,6 @@ case class IntHexastoreGraph[S, P, O](hexaTriples: HexastoreTriples[Int], dicts:
 
 object IntHexastoreGraph {
 
-  def empty[S, P, O]: IntHexastoreGraph[S, P, O] = IntHexastoreGraph[S, P, O](HexastoreTriples.empty[Int], IntSPODictionary.empty[S, P, O], 0)
+  def empty[S, P, O]: IntHexastoreGraph[S, P, O] = IntHexastoreGraph[S, P, O](HexastoreTriples.empty[Int], IntBTreeSPODictionaries.empty[S, P, O], 0)
 
 }

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntHexastoreGraph.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntHexastoreGraph.scala
@@ -1,0 +1,112 @@
+package org.w3.banana.plantain.model
+
+class IntSPODictionary[S, P, O](
+                                 subjectMap: Map[Int, S],
+                                 predicateMap: Map[Int, P],
+                                 objectMap: Map[Int, O],
+                                 rsubjectMap: Map[S, Int],
+                                 rpredicateMap: Map[P, Int],
+                                 robjectMap: Map[O, Int],
+                                 counter: Int
+                               ) extends SPODictionaries[Int, S, P, O] {
+
+
+  override def subjectOf(s: Int): S = subjectMap(s)
+
+  override def objectOf(o: Int): O = objectMap(o)
+
+  override def predicateOf(p: Int): P = predicateMap(p)
+
+  override def fromSubject(s: S): Int = rsubjectMap(s)
+
+  override def fromObject(o: O): Int = robjectMap(o)
+
+  override def fromPredicate(p: P): Int = rpredicateMap(p)
+
+  override def hasSubject(s: S): Boolean = rsubjectMap.contains(s)
+
+  override def hasObject(o: O): Boolean = robjectMap.contains(o)
+
+  override def hasPredicate(p: P): Boolean = rpredicateMap.contains(p)
+
+  override def newFromTriple(s: S, p: P, o: O): (Int, Int, Int, SPODictionaries[Int, S, P, O]) = {
+    var newCounter = counter
+    val subj = rsubjectMap.get(s) match {
+      case Some(num) => (num, subjectMap, rsubjectMap)
+      case _ => newCounter = newCounter + 1
+        (newCounter, subjectMap + (newCounter -> s), rsubjectMap + (s -> newCounter))
+    }
+    val pred = rpredicateMap.get(p) match {
+      case Some(num) => (num, predicateMap, rpredicateMap)
+      case _ => newCounter = newCounter + 1
+        (newCounter, predicateMap + (newCounter -> p), rpredicateMap + (p -> newCounter))
+    }
+    val obj = robjectMap.get(o) match {
+      case Some(num) => (num, objectMap, robjectMap)
+      case _ => newCounter = newCounter + 1
+        (newCounter, objectMap + (newCounter -> o), robjectMap + (o -> newCounter))
+    }
+    (subj._1, pred._1, obj._1, new IntSPODictionary(
+      subj._2, pred._2, obj._2,
+      subj._3, pred._3, obj._3,
+      newCounter
+    ))
+
+
+  }
+
+  override def removeFromSubjects(s: S): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+    subjectMap - fromSubject(s), predicateMap, objectMap,
+    rsubjectMap - s, rpredicateMap, robjectMap,
+    counter
+  )
+
+  override def removeFromPredicates(p: P): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+    subjectMap, predicateMap - fromPredicate(p), objectMap,
+    rsubjectMap, rpredicateMap - p, robjectMap,
+    counter
+  )
+
+  override def removeFromObjects(o: O): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+    subjectMap, predicateMap, objectMap - fromObject(o),
+    rsubjectMap, rpredicateMap, robjectMap - o,
+    counter
+  )
+}
+
+object IntSPODictionary {
+
+  def empty[S, P, O]: IntSPODictionary[S, P, O] = new IntSPODictionary[S, P, O](
+    Map.empty[Int, S],
+    Map.empty[Int, P],
+    Map.empty[Int, O],
+    Map.empty[S, Int],
+    Map.empty[P, Int],
+    Map.empty[O, Int],
+    0
+  )
+
+}
+
+case class IntHexastoreGraph[S, P, O](hexaTriples: HexastoreTriples[Int], dicts: SPODictionaries[Int, S, P, O], size: Int) extends HexastoreGraph[Int, S, P, O] {
+  //override def size: Int = _size
+
+  //override def hexaTriples: HexastoreTriples[Int] = _hexaTriples
+
+  //override def dicts: SPODictionaries[Int, S, P, O] = _dicts
+
+  override def -(subject: S, predicate: P, objectt: O): IntHexastoreGraph[S, P, O] = super.-(subject, predicate, objectt).asInstanceOf[IntHexastoreGraph[S, P, O]]
+
+  override def +(subject: S, predicate: P, objectt: O): IntHexastoreGraph[S, P, O] = super.+(subject, predicate, objectt).asInstanceOf[IntHexastoreGraph[S, P, O]]
+
+  override def newHexastoreGraph(_hexaTriples: HexastoreTriples[Int], _dicts: SPODictionaries[Int, S, P, O], _size: Int): HexastoreGraph[Int, S, P, O] =
+    new IntHexastoreGraph[S, P, O](_hexaTriples, _dicts, _size)
+
+}
+
+
+object IntHexastoreGraph {
+
+  def empty[S, P, O]: IntHexastoreGraph[S, P, O] = IntHexastoreGraph[S, P, O](HexastoreTriples.empty[Int], IntSPODictionary.empty[S, P, O], 0)
+
+}

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntSPODictionary.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntSPODictionary.scala
@@ -8,7 +8,7 @@ class IntSPODictionary[S, P, O](
                                  rpredicateMap: Map[P, Int],
                                  robjectMap: Map[O, Int],
                                  counter: Int
-                               ) extends SPODictionaries[Int, S, P, O] {
+                               ) extends SPODictionary[Int, S, P, O] {
 
 
   override def subjectOf(s: Int): S = subjectMap(s)
@@ -29,7 +29,7 @@ class IntSPODictionary[S, P, O](
 
   override def hasPredicate(p: P): Boolean = rpredicateMap.contains(p)
 
-  override def newFromTriple(s: S, p: P, o: O): (Int, Int, Int, SPODictionaries[Int, S, P, O]) = {
+  override def newFromTriple(s: S, p: P, o: O): (Int, Int, Int, SPODictionary[Int, S, P, O]) = {
     var newCounter = counter
     val subj = rsubjectMap.get(s) match {
       case Some(num) => (num, subjectMap, rsubjectMap)
@@ -55,19 +55,19 @@ class IntSPODictionary[S, P, O](
 
   }
 
-  override def removeSubjectKey(s: Int): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+  override def removeSubjectKey(s: Int): SPODictionary[Int, S, P, O] = new IntSPODictionary[S, P, O](
     subjectMap - s, predicateMap, objectMap,
     rsubjectMap - subjectOf(s), rpredicateMap, robjectMap,
     counter
   )
 
-  override def removePredicateKey(p: Int): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+  override def removePredicateKey(p: Int): SPODictionary[Int, S, P, O] = new IntSPODictionary[S, P, O](
     subjectMap, predicateMap - p, objectMap,
     rsubjectMap, rpredicateMap - predicateOf(p), robjectMap,
     counter
   )
 
-  override def removeObjectKey(o: Int): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+  override def removeObjectKey(o: Int): SPODictionary[Int, S, P, O] = new IntSPODictionary[S, P, O](
     subjectMap, predicateMap, objectMap - o,
     rsubjectMap, rpredicateMap, robjectMap - objectOf(o),
     counter

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntSPODictionary.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/IntSPODictionary.scala
@@ -1,0 +1,89 @@
+package org.w3.banana.plantain.model
+
+class IntSPODictionary[S, P, O](
+                                 subjectMap: Map[Int, S],
+                                 predicateMap: Map[Int, P],
+                                 objectMap: Map[Int, O],
+                                 rsubjectMap: Map[S, Int],
+                                 rpredicateMap: Map[P, Int],
+                                 robjectMap: Map[O, Int],
+                                 counter: Int
+                               ) extends SPODictionaries[Int, S, P, O] {
+
+
+  override def subjectOf(s: Int): S = subjectMap(s)
+
+  override def objectOf(o: Int): O = objectMap(o)
+
+  override def predicateOf(p: Int): P = predicateMap(p)
+
+  override def fromSubject(s: S): Int = rsubjectMap(s)
+
+  override def fromObject(o: O): Int = robjectMap(o)
+
+  override def fromPredicate(p: P): Int = rpredicateMap(p)
+
+  override def hasSubject(s: S): Boolean = rsubjectMap.contains(s)
+
+  override def hasObject(o: O): Boolean = robjectMap.contains(o)
+
+  override def hasPredicate(p: P): Boolean = rpredicateMap.contains(p)
+
+  override def newFromTriple(s: S, p: P, o: O): (Int, Int, Int, SPODictionaries[Int, S, P, O]) = {
+    var newCounter = counter
+    val subj = rsubjectMap.get(s) match {
+      case Some(num) => (num, subjectMap, rsubjectMap)
+      case _ => newCounter = newCounter + 1
+        (newCounter, subjectMap + (newCounter -> s), rsubjectMap + (s -> newCounter))
+    }
+    val pred = rpredicateMap.get(p) match {
+      case Some(num) => (num, predicateMap, rpredicateMap)
+      case _ => newCounter = newCounter + 1
+        (newCounter, predicateMap + (newCounter -> p), rpredicateMap + (p -> newCounter))
+    }
+    val obj = robjectMap.get(o) match {
+      case Some(num) => (num, objectMap, robjectMap)
+      case _ => newCounter = newCounter + 1
+        (newCounter, objectMap + (newCounter -> o), robjectMap + (o -> newCounter))
+    }
+    (subj._1, pred._1, obj._1, new IntSPODictionary(
+      subj._2, pred._2, obj._2,
+      subj._3, pred._3, obj._3,
+      newCounter
+    ))
+
+
+  }
+
+  override def removeSubjectKey(s: Int): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+    subjectMap - s, predicateMap, objectMap,
+    rsubjectMap - subjectOf(s), rpredicateMap, robjectMap,
+    counter
+  )
+
+  override def removePredicateKey(p: Int): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+    subjectMap, predicateMap - p, objectMap,
+    rsubjectMap, rpredicateMap - predicateOf(p), robjectMap,
+    counter
+  )
+
+  override def removeObjectKey(o: Int): SPODictionaries[Int, S, P, O] = new IntSPODictionary[S, P, O](
+    subjectMap, predicateMap, objectMap - o,
+    rsubjectMap, rpredicateMap, robjectMap - objectOf(o),
+    counter
+  )
+}
+
+object IntSPODictionary {
+
+  def empty[S, P, O]: IntSPODictionary[S, P, O] = new IntSPODictionary[S, P, O](
+    Map.empty[Int, S],
+    Map.empty[Int, P],
+    Map.empty[Int, O],
+    Map.empty[S, Int],
+    Map.empty[P, Int],
+    Map.empty[O, Int],
+    0
+  )
+
+}

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/SPODictionary.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/SPODictionary.scala
@@ -1,0 +1,33 @@
+package org.w3.banana.plantain.model
+
+trait SPODictionary[T, S, P, O] {
+
+  def subjectOf(s: T): S
+
+  def objectOf(o: T): O
+
+  def predicateOf(p: T): P
+
+  def removeSubjectKey(s: T): SPODictionary[T, S, P, O]
+
+  def removePredicateKey(p: T): SPODictionary[T, S, P, O]
+
+  def removeObjectKey(o: T): SPODictionary[T, S, P, O]
+
+  def tripleOf(triple: (T, T, T)): (S, P, O) = (subjectOf(triple._1), predicateOf(triple._2), objectOf(triple._3))
+
+  def fromSubject(s: S): T
+
+  def fromObject(o: O): T
+
+  def fromPredicate(p: P): T
+
+  def hasSubject(s: S): Boolean
+
+  def hasObject(o: O): Boolean
+
+  def hasPredicate(p: P): Boolean
+
+  def newFromTriple(s: S, p: P, o: O): (T, T, T, SPODictionary[T, S, P, O])
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,8 @@ object Dependencies {
     * @see http://scalaz.org
     * @see http://repo1.maven.org/maven2/org/scalaz/
     */
-  val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.8"
+  val scalazVersion = "7.3.0-M18"
+  val scalaz = "org.scalaz" %% "scalaz-core" % scalazVersion
 
   /**
    * joda-Time
@@ -29,14 +30,15 @@ object Dependencies {
    * @see http://www.scalatest.org
    * @see http://repo1.maven.org/maven2/org/scalatest
    */
-  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1"
+  val scalatestVersion = "3.0.1"
+  val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion
   
   /**
    * Akka Http Core
    * @see http://akka.io
    * @see http://repo1.maven.org/maven2/com/typesafe/akka
    */
-  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % "10.0.0"
+  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % "10.0.11"
 
   /**
    * Apache Commons Logging

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     * @see http://scalaz.org
     * @see http://repo1.maven.org/maven2/org/scalaz/
     */
-  val scalazVersion = "7.3.0-M18"
+  val scalazVersion = "7.3.0-M30"
   val scalaz = "org.scalaz" %% "scalaz-core" % scalazVersion
 
   /**

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,7 +24,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
   * @see http://www.scala-js.org/
   */
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 
 
 /**

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
 /**
   * Bintray pluging
@@ -24,7 +24,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
   * @see http://www.scala-js.org/
   */
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
 
 
 /**
@@ -33,7 +33,9 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
   * for drawing a dependency tree
   * @see https://github.com/gilt/sbt-dependency-graph-sugar
   */
-addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.7.5-1")
+//addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.8.2")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 /**
   * scala-style
@@ -41,7 +43,7 @@ addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.7.5-1")
   * for Scala style checking
   * @see http://www.scalastyle.org/
   */
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 
 /**
@@ -50,7 +52,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
   * better ivy alternative for dependency resolution
   * @see https://github.com/alexarchambault/coursier
   */
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
 
 /**
   * sbt-updates
@@ -58,4 +60,4 @@ addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")
   * for easier dependency updates monitoring
   * @see https://github.com/rtimush/sbt-updates
   */
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/PrefixTestSuite.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/PrefixTestSuite.scala
@@ -1,0 +1,45 @@
+package org.w3.banana.io
+
+import org.w3.banana.{Prefix, RDF, RDFOps}
+
+import scalaz._, scalaz.syntax.comonad._
+
+abstract class PrefixTestSuite[Rdf <: RDF, M[+ _] : Monad : Comonad](implicit
+  ops: RDFOps[Rdf],
+  reader: RDFReader[Rdf, M, Turtle],
+  val writer: RDFWriter[Rdf, M, Turtle]
+) extends SerialisationTestSuite[Rdf, M, Turtle, Turtle]("Turtle", "ttl") {
+  val referenceGraphSerialisedForSyntax =
+    """
+<http://www.w3.org/2001/sw/RDFCore/ntriples/> <http://purl.org/dc/elements/1.1/creator> "Dave Beckett", "Art Barstow" ;
+                                              <http://purl.org/dc/elements/1.1/publisher> <http://www.w3.org/> .
+  """
+
+  "write with prefixes" in {
+    val prefix = Set(Prefix[Rdf]("foo", "http://purl.org/dc/elements/1.1/"))
+
+    //    val expectedString =
+    //      """
+    //        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
+    //        |
+    //        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
+    //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
+    //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
+
+    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    withPrefix should include("@prefix foo:")
+    withPrefix should include("foo:creator")
+    withPrefix should include("foo:publisher")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
+
+    val noPrefix = writer.asString(referenceGraph, "").copoint
+    noPrefix should not include ("@prefix foo:")
+    noPrefix should not include ("foo:creator")
+    noPrefix should not include ("foo:publisher")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
+
+  }
+
+}

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/TurtleTestSuite.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/TurtleTestSuite.scala
@@ -6,7 +6,7 @@ import scalaz._
 abstract class TurtleTestSuite[Rdf <: RDF, M[+_] : Monad : Comonad](implicit
   ops: RDFOps[Rdf],
   reader: RDFReader[Rdf, M, Turtle],
-  writer: RDFWriter[Rdf, M, Turtle]
+  val writer: RDFWriter[Rdf, M, Turtle]
 ) extends SerialisationTestSuite[Rdf, M, Turtle, Turtle]("Turtle", "ttl") {
 
   val referenceGraphSerialisedForSyntax = """

--- a/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
@@ -5,10 +5,12 @@ import java.io.OutputStream
 
 trait RDFWriter[Rdf <: RDF, M[_], +T] extends Writer[Rdf#Graph,M,T] {
 
+  def write(graph: Rdf#Graph, os: OutputStream, base: String): M[Unit] = write(graph, os, base, Nil:_*)
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String): M[Unit]
+  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Prefix[Rdf]*): M[Unit]
 
-  def asString(graph: Rdf#Graph, base: String): M[String]
+  def asString(graph: Rdf#Graph, base: String): M[String] = asString(graph, base, Nil:_*)
+
+  def asString(graph: Rdf#Graph, base: String, prefixes: Prefix[Rdf]*): M[String]
 
 }
-

--- a/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
@@ -5,12 +5,12 @@ import java.io.OutputStream
 
 trait RDFWriter[Rdf <: RDF, M[_], +T] extends Writer[Rdf#Graph,M,T] {
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String): M[Unit] = write(graph, os, base, Nil:_*)
+  override def write(obj: Rdf#Graph, os: OutputStream, base: String): M[Unit] = write(obj, os, base, Set())
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Prefix[Rdf]*): M[Unit]
+  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Rdf]]): M[Unit]
 
-  def asString(graph: Rdf#Graph, base: String): M[String] = asString(graph, base, Nil:_*)
+  override def asString(obj: Rdf#Graph, base: String): M[String] = asString(obj, base, Set())
 
-  def asString(graph: Rdf#Graph, base: String, prefixes: Prefix[Rdf]*): M[String]
+  def asString(graph: Rdf#Graph, base: String, prefixes: Set[Prefix[Rdf]]): M[String]
 
 }

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
@@ -1,5 +1,6 @@
 package org.w3.banana.sesame.io
 
+import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.sesame._
 import java.io._
@@ -10,14 +11,14 @@ class SesameRDFWriter[T](implicit
   sesameSyntax: SesameSyntax[T]
 ) extends RDFWriter[Sesame, Try, T] {
 
-  def write(graph: Sesame#Graph, os: OutputStream, base: String): Try[Unit] = Try {
+  def write(graph: Sesame#Graph, os: OutputStream, base: String, prefixes: Prefix[Sesame]*): Try[Unit] = Try {
     val sWriter = sesameSyntax.rdfWriter(os, base)
     sWriter.startRDF()
     ops.getTriples(graph) foreach sWriter.handleStatement
     sWriter.endRDF()
   }
 
-  def asString(graph: Sesame#Graph, base: String): Try[String] = Try {
+  def asString(graph: Sesame#Graph, base: String, prefixes: Prefix[Sesame]*): Try[String] = Try {
     val result = new StringWriter()
     val sWriter = sesameSyntax.rdfWriter(result, base)
     sWriter.startRDF()

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
@@ -13,6 +13,9 @@ class SesameRDFWriter[T](implicit
 
   def write(graph: Sesame#Graph, os: OutputStream, base: String, prefixes: Prefix[Sesame]*): Try[Unit] = Try {
     val sWriter = sesameSyntax.rdfWriter(os, base)
+    prefixes.foreach(p => {
+      sWriter.handleNamespace(p.prefixName, p.prefixIri)
+    })
     sWriter.startRDF()
     ops.getTriples(graph) foreach sWriter.handleStatement
     sWriter.endRDF()
@@ -21,6 +24,9 @@ class SesameRDFWriter[T](implicit
   def asString(graph: Sesame#Graph, base: String, prefixes: Prefix[Sesame]*): Try[String] = Try {
     val result = new StringWriter()
     val sWriter = sesameSyntax.rdfWriter(result, base)
+    prefixes.foreach(p => {
+      sWriter.handleNamespace(p.prefixName, p.prefixIri)
+    })
     sWriter.startRDF()
     ops.getTriples(graph) foreach sWriter.handleStatement
     sWriter.endRDF()

--- a/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
+++ b/sesame/src/main/scala/org/w3/banana/sesame/io/SesameRDFWriter.scala
@@ -11,7 +11,7 @@ class SesameRDFWriter[T](implicit
   sesameSyntax: SesameSyntax[T]
 ) extends RDFWriter[Sesame, Try, T] {
 
-  def write(graph: Sesame#Graph, os: OutputStream, base: String, prefixes: Prefix[Sesame]*): Try[Unit] = Try {
+  def write(graph: Sesame#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Sesame]]): Try[Unit] = Try {
     val sWriter = sesameSyntax.rdfWriter(os, base)
     prefixes.foreach(p => {
       sWriter.handleNamespace(p.prefixName, p.prefixIri)
@@ -21,7 +21,7 @@ class SesameRDFWriter[T](implicit
     sWriter.endRDF()
   }
 
-  def asString(graph: Sesame#Graph, base: String, prefixes: Prefix[Sesame]*): Try[String] = Try {
+  def asString(graph: Sesame#Graph, base: String, prefixes: Set[Prefix[Sesame]]): Try[String] = Try {
     val result = new StringWriter()
     val sWriter = sesameSyntax.rdfWriter(result, base)
     prefixes.foreach(p => {

--- a/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
+++ b/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
@@ -1,41 +1,14 @@
 package org.w3.banana.sesame.io
 
-import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.sesame._
-
-import scala.util.Try
 import org.w3.banana.util.tryInstances._
 
-class SesameTurtleTests extends TurtleTestSuite[Sesame, Try] {
+import scala.util.Try
 
-  "write with prefixes" in {
-    val prefix = Set(Prefix[Sesame]("foo", "http://purl.org/dc/elements/1.1/"))
+class SesameTurtleTests extends TurtleTestSuite[Sesame, Try]
 
-    //    val expectedString =
-    //      """
-    //        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
-    //        |
-    //        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
-    //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
-    //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
-
-    val withPrefix = writer.asString(referenceGraph, "", prefix).get
-    withPrefix should include("@prefix foo:")
-    withPrefix should include("foo:creator")
-    withPrefix should include("foo:publisher")
-    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
-    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
-
-    val noPrefix = writer.asString(referenceGraph, "").get
-    noPrefix should not include ("@prefix foo:")
-    noPrefix should not include ("foo:creator")
-    noPrefix should not include ("foo:publisher")
-    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
-    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
-
-  }
-}
+class SesamePrefixTest extends PrefixTestSuite[Sesame, Try]
 
 class SesameNTripleReaderTestSuite extends NTriplesReaderTestSuite[Sesame]
 

--- a/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
+++ b/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
@@ -6,12 +6,11 @@ import org.w3.banana.sesame._
 
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
-import scalaz.syntax._, comonad._
 
 class SesameTurtleTests extends TurtleTestSuite[Sesame, Try] {
 
   "write with prefixes" in {
-    val prefix = Prefix[Sesame]("foo", "http://purl.org/dc/elements/1.1/")
+    val prefix = Set(Prefix[Sesame]("foo", "http://purl.org/dc/elements/1.1/"))
 
     //    val expectedString =
     //      """
@@ -21,14 +20,14 @@ class SesameTurtleTests extends TurtleTestSuite[Sesame, Try] {
     //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
     //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
 
-    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    val withPrefix = writer.asString(referenceGraph, "", prefix).get
     withPrefix should include("@prefix foo:")
     withPrefix should include("foo:creator")
     withPrefix should include("foo:publisher")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
 
-    val noPrefix = writer.asString(referenceGraph, "").copoint
+    val noPrefix = writer.asString(referenceGraph, "").get
     noPrefix should not include ("@prefix foo:")
     noPrefix should not include ("foo:creator")
     noPrefix should not include ("foo:publisher")

--- a/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
+++ b/sesame/src/test/scala/org/w3/banana/sesame/io/SesameSerialisationTests.scala
@@ -1,11 +1,42 @@
 package org.w3.banana.sesame.io
 
+import org.w3.banana.Prefix
 import org.w3.banana.io._
 import org.w3.banana.sesame._
+
 import scala.util.Try
 import org.w3.banana.util.tryInstances._
+import scalaz.syntax._, comonad._
 
-class SesameTurtleTests extends TurtleTestSuite[Sesame, Try]
+class SesameTurtleTests extends TurtleTestSuite[Sesame, Try] {
+
+  "write with prefixes" in {
+    val prefix = Prefix[Sesame]("foo", "http://purl.org/dc/elements/1.1/")
+
+    //    val expectedString =
+    //      """
+    //        |@prefix foo:   <http://purl.org/dc/elements/1.1/> .
+    //        |
+    //        |<http://www.w3.org/2001/sw/RDFCore/ntriples/>
+    //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
+    //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
+
+    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    withPrefix should include("@prefix foo:")
+    withPrefix should include("foo:creator")
+    withPrefix should include("foo:publisher")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
+    withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
+
+    val noPrefix = writer.asString(referenceGraph, "").copoint
+    noPrefix should not include ("@prefix foo:")
+    noPrefix should not include ("foo:creator")
+    noPrefix should not include ("foo:publisher")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/creator>")
+    noPrefix should include("<http://purl.org/dc/elements/1.1/publisher>")
+
+  }
+}
 
 class SesameNTripleReaderTestSuite extends NTriplesReaderTestSuite[Sesame]
 


### PR DESCRIPTION
Especially in scala.js I recognized slow speed accessing graph structured of moderate size. here I present an approach to get a better performance using
an immutable Hexastore approach, with a dictionary mapping URIs/Strings to Integers.
It keeps a lookup `Map[Map[Vecor[]]]` with the following combinations
   `spo, sop, pso, pos, osp, ops`
Probably 5 of these are enough to cover all cases in pattern matching.

I continue this approach by using a mutable B+Tree for the dictionary (and later possibly also for the maps) to gain even more performance (insert and query with `O(log N)` ), which you can follow here [bastiion:BPlusTree](https://github.com/bastiion/banana-rdf/tree/BPlusTree)

I folow the approach of

 "[Hexastore](http://dx.doi.org/10.14778/1453856.1453965): Sextuple Indexing for Semantic Web Data Management" by Weiss, Karras, und Bernstein

Could this be an option?
If yes I would try to unfiddle the commits again from the other "non necessary" changes... 