### PR TITLE
RDF4J 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,24 @@ lazy val sesame = Project("sesame", file("sesame"))
     )
   ).dependsOn(rdfJVM, ntriplesJVM, rdfTestSuiteJVM % "test->compile")
 
+lazy val rdf4j = Project("rdf4j", file("rdf4j"))
+  .settings(commonSettings: _*)
+  .settings(
+    name := "banana-rdf4j",
+    libraryDependencies ++= Seq(
+      rdf4jQueryAlgebra,
+      rdf4jQueryParser,
+      rdf4jQueryResult,
+      rdf4jRioTurtle,
+      rdf4jRioRdfxml,
+      rdf4jRioJsonld,
+      rdf4jSailMemory,
+      rdf4jSailNativeRdf,
+      rdf4jRepositorySail,
+      commonsLogging
+    )
+  ).dependsOn(rdfJVM, ntriplesJVM, rdfTestSuiteJVM % "test->compile")
+
 lazy val jsonldJS = Project("jsonld", file("jsonld.js"))
   .settings(commonSettings: _*)
   .settings()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,8 @@ object Dependencies {
     * @see http://scalaz.org
     * @see http://repo1.maven.org/maven2/org/scalaz/
     */
-  val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.8"
+  val scalazVersion = "7.3.0-M18"
+  val scalaz = "org.scalaz" %% "scalaz-core" % scalazVersion
 
   /**
    * joda-Time
@@ -29,14 +30,15 @@ object Dependencies {
    * @see http://www.scalatest.org
    * @see http://repo1.maven.org/maven2/org/scalatest
    */
-  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1"
+  val scalatestVersion = "3.0.1"
+  val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion
   
   /**
    * Akka Http Core
    * @see http://akka.io
    * @see http://repo1.maven.org/maven2/com/typesafe/akka
    */
-  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % "10.0.0"
+  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % "10.0.11"
 
   /**
    * Apache Commons Logging

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,6 +85,23 @@ object Dependencies {
   val sesameRepositorySail = "org.openrdf.sesame" % "sesame-repository-sail" % sesameVersion
 
   /**
+   * rdf4j
+   * @see https://rdf4j.eclipse.org/
+   **/
+  val rdf4jVersion = "3.0.0"
+
+  val rdf4jQueryAlgebra = "org.eclipse.rdf4j" % "rdf4j-queryalgebra-evaluation" % rdf4jVersion
+  val rdf4jQueryParser = "org.eclipse.rdf4j" % "rdf4j-queryparser-sparql" % rdf4jVersion
+  val rdf4jQueryResult = "org.eclipse.rdf4j" % "rdf4j-queryresultio-sparqljson" % rdf4jVersion
+  val rdf4jRioTurtle = "org.eclipse.rdf4j" % "rdf4j-rio-turtle" % rdf4jVersion
+  val rdf4jRioRdfxml =  "org.eclipse.rdf4j" % "rdf4j-rio-rdfxml" % rdf4jVersion
+  val rdf4jRioJsonld =  "org.eclipse.rdf4j" % "rdf4j-rio-jsonld" % rdf4jVersion
+  val rdf4jSailMemory = "org.eclipse.rdf4j" % "rdf4j-sail-memory" % rdf4jVersion
+  val rdf4jSailNativeRdf = "org.eclipse.rdf4j" % "rdf4j-sail-nativerdf" % rdf4jVersion
+  val rdf4jRepositorySail = "org.eclipse.rdf4j" % "rdf4j-repository-sail" % rdf4jVersion
+
+
+  /**
    * jsonld-java
    * @see https://github.com/jsonld-java/jsonld-java
    * @see http://repo.typesafe.com/typesafe/snapshots/com/github/jsonld-java/jsonld-java-sesame

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
 /**
   * Bintray pluging
@@ -24,7 +24,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
   * @see http://www.scala-js.org/
   */
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
 
 
 /**
@@ -33,7 +33,9 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
   * for drawing a dependency tree
   * @see https://github.com/gilt/sbt-dependency-graph-sugar
   */
-addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.7.5-1")
+//addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.8.2")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 
 /**
   * scala-style
@@ -41,7 +43,7 @@ addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.7.5-1")
   * for Scala style checking
   * @see http://www.scalastyle.org/
   */
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 
 /**
@@ -50,7 +52,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
   * better ivy alternative for dependency resolution
   * @see https://github.com/alexarchambault/coursier
   */
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC13")
 
 /**
   * sbt-updates
@@ -58,4 +60,4 @@ addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
   * for easier dependency updates monitoring
   * @see https://github.com/rtimush/sbt-updates
   */
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/io/NTriplesReaderTestSuite.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/io/NTriplesReaderTestSuite.scala
@@ -516,14 +516,14 @@ class NTriplesReaderTestSuite[Rdf <: RDF](implicit
 
   "w3c tests of type rdft:TestNTriplesNegativeSyntax" should {
 
-    def fail(s: String,erros: Int, test: List[Try[Rdf#Triple]] => Boolean = _ => true) = {
+    def fail(s: String,erros: Int*) = {
       val parseIterator = ntparser(s,true)
       val resultList = parseIterator.toList
-      assert(test(resultList))
-      assert(resultList.filter{
+      val resultListErrorSize =resultList.filter{
         case Failure(ParseException(_,-1,_))=>false
         case _ => true
-      }.size == erros)
+      }.size
+      assert(erros.contains(resultListErrorSize))
     }
 
     "nt-syntax-bad-uri-01" in {
@@ -577,7 +577,7 @@ class NTriplesReaderTestSuite[Rdf <: RDF](implicit
     }
     "nt-syntax-bad-lang-01" in {
       fail("""# Bad lang tag
-             |<http://example/s> <http://example/p> "string"@1 .""".stripMargin,1)
+             |<http://example/s> <http://example/p> "string"@1 .""".stripMargin,1, 2)
     }
     "nt-syntax-bad-esc-01" in {
       fail("""# Bad string escape

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4j.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4j.scala
@@ -1,0 +1,42 @@
+package org.w3.banana.rd4j
+
+import org.eclipse.rdf4j.model.{Model, Statement, Value}
+import org.eclipse.rdf4j.model.{BNode => Rdf4jBNode, IRI => Rdf4jIRI, Literal => Rdf4jLiteral, _}
+import org.eclipse.rdf4j.query.BindingSet
+import org.eclipse.rdf4j.query.parser.{ParsedBooleanQuery, ParsedGraphQuery, ParsedQuery, ParsedTupleQuery, ParsedUpdate}
+import org.w3.banana.RDF
+
+trait Rdf4j extends RDF {
+
+
+  type Graph = Model
+  type Triple = Statement
+  type Node = Value
+  type URI = Rdf4jIRI
+  type BNode = Rdf4jBNode
+  type Literal = Rdf4jLiteral
+  type Lang = String
+
+
+  // mutable graphs
+  type MGraph = Model
+
+  // types for the graph traversal API
+  type NodeMatch = Value
+  type NodeAny = Null
+  type NodeConcrete = Value
+
+  // types related to Sparql
+  type Query = ParsedQuery
+  type SelectQuery = ParsedTupleQuery
+  type ConstructQuery = ParsedGraphQuery
+  type AskQuery = ParsedBooleanQuery
+  type UpdateQuery = ParsedUpdate
+
+  type Solution = BindingSet
+  // instead of TupleQueryResult so that it's eager instead of lazy
+  type Solutions = Stream[BindingSet]
+
+}
+
+object Rdf4j extends Rdf4jModule

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jGraphSparqlEngine.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jGraphSparqlEngine.scala
@@ -1,0 +1,50 @@
+package org.w3.banana.rd4j
+
+
+import org.eclipse.rdf4j.repository.sail.{SailRepository, SailRepositoryConnection}
+import org.eclipse.rdf4j.sail.memory.MemoryStore
+import org.w3.banana._
+
+import scala.concurrent.Future
+import scala.util.Try
+
+/**
+ * Treat a Graph as a Sparql Engine
+ */
+class Rdf4jGraphSparqlEngine extends SparqlEngine[Rdf4j, Try, Rdf4j#Graph] {
+
+  val store = new Rdf4jStore()
+
+  def withConnection[T](repository: SailRepository)(func: SailRepositoryConnection => T): Future[T] = Future.successful {
+    val conn = repository.getConnection
+    val result = func(conn)
+    conn.commit()
+    conn.close()
+    result
+  }
+
+  def asConn(graph: Rdf4j#Graph) = {
+    val store = new MemoryStore
+    val sail = new SailRepository(store)
+    sail.init()
+    withConnection(sail) { conn =>
+      conn.add(graph)
+    }
+    sail.getConnection()
+  }
+
+  def executeSelect(graph: Rdf4j#Graph, query: Rdf4j#SelectQuery, bindings: Map[String, Rdf4j#Node]): Try[Rdf4j#Solutions] =
+    store.executeSelect(asConn(graph), query, bindings)
+
+  def executeConstruct(graph: Rdf4j#Graph, query: Rdf4j#ConstructQuery, bindings: Map[String, Rdf4j#Node]): Try[Rdf4j#Graph] =
+    store.executeConstruct(asConn(graph), query, bindings)
+
+  def executeAsk(graph: Rdf4j#Graph, query: Rdf4j#AskQuery, bindings: Map[String, Rdf4j#Node]): Try[Boolean] =
+    store.executeAsk(asConn(graph), query, bindings)
+
+}
+
+object Rdf4jGraphSparqlEngine {
+  def apply() = new Rdf4jGraphSparqlEngine()
+}
+

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jMGraphOps.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jMGraphOps.scala
@@ -1,0 +1,35 @@
+package org.w3.banana.rd4j
+
+import org.eclipse.rdf4j.model.impl.LinkedHashModel
+import org.w3.banana.MGraphOps
+
+trait Rdf4jMGraphOps extends MGraphOps[Rdf4j] { self: Rdf4jOps =>
+
+  final def makeMGraph(graph: Rdf4j#Graph): Rdf4j#MGraph = {
+    val mgraph = makeEmptyMGraph()
+    addTriples(mgraph, self.getTriples(graph))
+  }
+
+  final def makeEmptyMGraph(): Rdf4j#MGraph = new LinkedHashModel
+
+  final def addTriple(mgraph: Rdf4j#MGraph, triple: Rdf4j#Triple): mgraph.type = {
+    mgraph.add(triple)
+    mgraph
+  }
+
+  final def removeTriple(mgraph: Rdf4j#MGraph, triple: Rdf4j#Triple): mgraph.type = {
+    mgraph.remove(triple)
+    mgraph
+  }
+
+  final def exists(mgraph: Rdf4j#MGraph, triple: Rdf4j#Triple): Boolean =
+    mgraph.contains(triple)
+
+  final def sizeMGraph(mgraph: Rdf4j#MGraph): Int = mgraph.size
+
+  final def makeIGraph(mgraph: Rdf4j#MGraph): Rdf4j#Graph = mgraph
+
+
+
+
+}

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jModule.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jModule.scala
@@ -1,0 +1,74 @@
+package org.w3.banana.rd4j
+
+import org.eclipse.rdf4j.repository.RepositoryConnection
+import org.w3.banana.{JsonQueryResultsReaderModule, XmlQueryResultsReaderModule, XmlSolutionsWriterModule, _}
+import org.w3.banana.io._
+import org.w3.banana.rd4j.io._
+
+import scala.util.Try
+
+trait Rdf4jModule
+  extends RDFModule
+    with RDFOpsModule
+    with RecordBinderModule
+    with SparqlGraphModule
+    with RDFXMLReaderModule
+    with TurtleReaderModule
+    with NTriplesReaderModule
+    with JsonLDReaderModule
+    with RDFXMLWriterModule
+    with TurtleWriterModule
+    with NTriplesWriterModule
+    with JsonLDWriterModule
+    with JsonSolutionsWriterModule
+    with XmlSolutionsWriterModule
+    with JsonQueryResultsReaderModule
+    with XmlQueryResultsReaderModule {
+
+  type Rdf = Rdf4j
+
+  implicit val ops: Rdf4jOps = new Rdf4jOps
+
+  implicit val recordBinder: binder.RecordBinder[Rdf4j] = binder.RecordBinder[Rdf4j]
+
+  implicit val sparqlOps: SparqlOps[Rdf4j] = Rdf4jSparqlOps
+
+  implicit val sparqlGraph: SparqlEngine[Rdf4j, Try, Rdf4j#Graph] = Rdf4jGraphSparqlEngine()
+
+  implicit val rdfStore: RDFStore[Rdf4j, Try, RepositoryConnection] with SparqlUpdate[Rdf4j, Try, RepositoryConnection] = new Rdf4jStore
+
+  implicit val rdfXMLReader: RDFReader[Rdf4j, Try, RDFXML] = new Rdf4jRDFXMLReader
+
+  implicit val turtleReader: RDFReader[Rdf4j, Try, Turtle] = new Rdf4jTurtleReader
+
+  implicit val jsonldReader: RDFReader[Rdf4j, Try, JsonLd] = new Rdf4jJSONLDReader
+
+  implicit val ntriplesReader: RDFReader[Rdf4j, Try, NTriples] = new NTriplesReader
+
+  implicit val sesameRDFWriterHelper = new Rdf4jRDFWriterHelper
+
+  implicit val rdfXMLWriter: RDFWriter[Rdf4j, Try, RDFXML] = sesameRDFWriterHelper.rdfxmlWriter
+
+  implicit val turtleWriter: RDFWriter[Rdf4j, Try, Turtle] = sesameRDFWriterHelper.turtleWriter
+
+  implicit val ntriplesWriter: RDFWriter[Rdf4j, Try, NTriples] = new NTriplesWriter
+
+  implicit val jsonldCompactedWriter: RDFWriter[Rdf4j, Try, JsonLdCompacted] = sesameRDFWriterHelper.jsonldCompactedWriter
+
+  implicit val jsonldExpandedWriter: RDFWriter[Rdf4j, Try, JsonLdExpanded] = sesameRDFWriterHelper.jsonldExpandedWriter
+
+  implicit val jsonldFlattenedWriter: RDFWriter[Rdf4j, Try, JsonLdFlattened] = sesameRDFWriterHelper.jsonldFlattenedWriter
+
+  implicit val jsonSolutionsWriter: SparqlSolutionsWriter[Rdf4j, SparqlAnswerJson] =
+    Rdf4jSolutionsWriter.solutionsWriterJson
+
+  implicit val xmlSolutionsWriter: SparqlSolutionsWriter[Rdf4j, SparqlAnswerXml] =
+    Rdf4jSolutionsWriter.solutionsWriterXml
+
+  implicit val jsonQueryResultsReader: SparqlQueryResultsReader[Rdf4j, SparqlAnswerJson] =
+    Rdf4jQueryResultsReader.queryResultsReaderJson
+
+  implicit val xmlQueryResultsReader: SparqlQueryResultsReader[Rdf4j, SparqlAnswerXml] =
+    Rdf4jQueryResultsReader.queryResultsReaderXml
+
+}

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jOps.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jOps.scala
@@ -1,0 +1,164 @@
+package org.w3.banana.rd4j
+
+import java.util.Locale
+
+import org.w3.banana.{DefaultURIOps, RDFOps}
+import org.w3.banana.rd4j.helper.JavaOptionals._
+import org.eclipse.rdf4j.model._
+import org.eclipse.rdf4j.model.impl._
+import org.eclipse.rdf4j.model.util._
+
+import scala.collection.JavaConverters._
+
+class Rdf4jOps extends RDFOps[Rdf4j] with Rdf4jMGraphOps with DefaultURIOps[Rdf4j] {
+
+  val valueFactory: ValueFactory = SimpleValueFactory.getInstance()
+
+
+  def emptyGraph: Rdf4j#Graph = new LinkedHashModel
+
+  def makeGraph(it: Iterable[Rdf4j#Triple]): Rdf4j#Graph = {
+    val graph = new LinkedHashModel
+    it foreach { t => graph add t }
+    graph
+  }
+  def getTriples(graph: Rdf4j#Graph): Iterable[Rdf4j#Triple] = graph.asScala
+
+  // triple
+
+  def makeTriple(s: Rdf4j#Node, p: Rdf4j#URI, o: Rdf4j#Node): Rdf4j#Triple =
+    s match {
+      case res:Resource=>  valueFactory.createStatement(res, p, o)
+      case _=> throw new RuntimeException("makeTriple: in Rdf4j subject " + p.toString + " must be a either URI or BlankNode")
+    }
+
+  def fromTriple(t: Rdf4j#Triple): (Rdf4j#Node, Rdf4j#URI, Rdf4j#Node) =  (t.getSubject, t.getPredicate, t.getObject)
+
+  // node
+
+  def foldNode[T](node: Rdf4j#Node)(funURI: Rdf4j#URI => T, funBNode: Rdf4j#BNode => T, funLiteral: Rdf4j#Literal => T): T = node match {
+    case iri: Rdf4j#URI => funURI(iri)
+    case bnode: Rdf4j#BNode => funBNode(bnode)
+    case literal: Rdf4j#Literal => funLiteral(literal)
+  }
+
+  // URI
+
+  /**
+    * we provide our own builder for Rdf4j#URI to relax the constraint "the URI must be absolute"
+    * this constraint becomes relevant only when you add the URI to a Rdf4j store
+    */
+  def makeUri(iriStr: String): Rdf4j#URI = {
+    try {
+      valueFactory.createIRI(iriStr)
+    } catch {
+      case iae: IllegalArgumentException =>
+        new IRI {
+          override def equals(o: Any): Boolean = o.isInstanceOf[IRI] && o.asInstanceOf[IRI].toString == iriStr
+          def getLocalName: String = iriStr
+          def getNamespace: String = ""
+          override def hashCode: Int = iriStr.hashCode
+          override def toString: String = iriStr
+          def stringValue: String = iriStr
+        }
+    }
+
+  }
+
+  def fromUri(node: Rdf4j#URI): String = node.toString
+
+  // bnode
+
+  def makeBNode() = valueFactory.createBNode()
+
+  def makeBNodeLabel(label: String): Rdf4j#BNode = valueFactory.createBNode(label)
+
+  def fromBNode(bn: Rdf4j#BNode): String = bn.getID
+  // literal
+
+  val __xsdString = makeUri("http://www.w3.org/2001/XMLSchema#string")
+  val __rdfLangString = makeUri("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")
+
+  def makeLiteral(lexicalForm: String, datatype: Rdf4j#URI): Rdf4j#Literal =
+    valueFactory.createLiteral(lexicalForm, datatype)
+
+  def makeLangTaggedLiteral(lexicalForm: String, lang: Rdf4j#Lang): Rdf4j#Literal =
+    valueFactory.createLiteral(lexicalForm, lang)
+
+  def fromLiteral(literal: Rdf4j#Literal): (String, Rdf4j#URI, Option[Rdf4j#Lang]) =
+    (literal.getLabel, literal.getDatatype, literal.getLanguage.toOption)
+
+  /**
+    *  language tags are cases insensitive according to
+    * <a href="http://tools.ietf.org/html/bcp47#section-2.1.1">RFC 5646: Tags for Identifying Languages</a>
+    * which is referenced by <a href="http://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal">RDF11 Concepts</a>.
+    * Rdf4j does not take this into account, so canonicalise here to lower case. ( The NTriples Tests don't pass
+    * if the `.toLowerCase` transformation is removed .
+    */
+  def makeLang(langString: String): Rdf4j#Lang = langString.toLowerCase(Locale.ENGLISH)
+
+  def fromLang(lang: Rdf4j#Lang): String = lang
+
+  // graph traversal
+
+  val ANY: Rdf4j#NodeAny = null
+
+  implicit def toConcreteNodeMatch(node: Rdf4j#Node): Rdf4j#NodeMatch = node.asInstanceOf[Rdf4j#Node]
+
+  def foldNodeMatch[T](nodeMatch: Rdf4j#NodeMatch)(funANY: => T, funConcrete: Rdf4j#Node => T): T =
+    if (nodeMatch == null)
+      funANY
+    else
+      funConcrete(nodeMatch.asInstanceOf[Rdf4j#Node])
+
+  def find(graph: Rdf4j#Graph, subject: Rdf4j#NodeMatch, predicate: Rdf4j#NodeMatch, objectt: Rdf4j#NodeMatch): Iterator[Rdf4j#Triple] = {
+    def sOpt: Option[Resource] =
+      if (subject == null)
+        Some(null)
+      else
+        foldNode(subject)(Some.apply, Some.apply, _ => None)
+    def pOpt: Option[Rdf4j#URI] =
+      if (predicate == null)
+        Some(null)
+      else
+        foldNode(predicate)(Some.apply, _ => None, _ => None)
+    val r = for {
+      s <- sOpt
+      p <- pOpt
+    } yield {
+      graph.filter(s, p, objectt).iterator.asScala
+    }
+    r getOrElse Iterator.empty
+  }
+
+  // graph union
+
+  def union(graphs: Seq[Rdf4j#Graph]): Rdf4j#Graph = {
+    graphs match {
+      case Seq(x) => x
+      case _ =>
+        val graph = new LinkedHashModel
+        graphs.foreach(g => getTriples(g) foreach { triple => graph.add(triple) })
+        graph
+    }
+  }
+
+  def diff(g1: Rdf4j#Graph, g2: Rdf4j#Graph): Rdf4j#Graph = {
+    val graph = new LinkedHashModel
+    getTriples(g1) foreach { triple =>
+      if (!g2.contains(triple)) graph add triple
+    }
+    graph
+  }
+
+  // graph isomorphism
+  def isomorphism(left: Rdf4j#Graph, right: Rdf4j#Graph): Boolean = {
+    val leftNoContext = left.asScala.map(s => makeTriple(s.getSubject, s.getPredicate, s.getObject)).asJava
+    val rightNoContext = right.asScala.map(s => makeTriple(s.getSubject, s.getPredicate, s.getObject)).asJava
+    Models.isomorphic(leftNoContext, rightNoContext)
+  }
+
+  def graphSize(g: Rdf4j#Graph): Int = g.size()
+
+
+}

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jPrefix.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jPrefix.scala
@@ -1,0 +1,15 @@
+package org.w3.banana.rd4j
+
+import org.w3.banana._
+
+class Rdf4jPrefix(implicit ops: RDFOps[Rdf4j]) {
+
+  val rdf = RDFPrefix[Rdf4j]
+
+  val xsd = XSDPrefix[Rdf4j]
+
+  val dc = DCPrefix[Rdf4j]
+
+  val foaf = FOAFPrefix[Rdf4j]
+
+}

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jSparqlOps.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jSparqlOps.scala
@@ -1,0 +1,58 @@
+package org.w3.banana.rd4j
+
+import org.eclipse.rdf4j.query.parser.{ParsedBooleanQuery, ParsedGraphQuery, ParsedTupleQuery, QueryParserUtil}
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParserFactory
+import org.w3.banana.SparqlOps.withPrefixes
+import org.w3.banana._
+
+import scala.util._
+import scala.collection.JavaConverters._
+
+object Rdf4jSparqlOps extends SparqlOps[Rdf4j] {
+
+  private val p = new SPARQLParserFactory().getParser()
+
+  def parseSelect(query: String, prefixes: Seq[Prefix[Rdf4j]]): Try[Rdf4j#SelectQuery] = Try {
+    p.parseQuery(withPrefixes(query, prefixes), "http://todo.example/").asInstanceOf[ParsedTupleQuery]
+  }
+
+  def parseConstruct(query: String, prefixes: Seq[Prefix[Rdf4j]]): Try[Rdf4j#ConstructQuery] = Try {
+    p.parseQuery(withPrefixes(query, prefixes), "http://todo.example/").asInstanceOf[ParsedGraphQuery]
+  }
+
+  def parseAsk(query: String, prefixes: Seq[Prefix[Rdf4j]]): Try[Rdf4j#AskQuery] = Try {
+    p.parseQuery(withPrefixes(query, prefixes), "http://todo.example/").asInstanceOf[ParsedBooleanQuery]
+  }
+
+  def parseUpdate(query: String, prefixes: Seq[Prefix[Rdf4j]]): Try[Rdf4j#UpdateQuery] = Try {
+    p.parseUpdate(withPrefixes(query, prefixes), "http://todo.example/")
+  }
+
+  def parseQuery(query: String, prefixes: Seq[Prefix[Rdf4j]]): Try[Rdf4j#Query] = Try {
+    p.parseQuery(withPrefixes(query, prefixes), "http://todo.example/")
+  }
+
+  def fold[T](
+    query: Rdf4j#Query)(
+      select: (Rdf4j#SelectQuery) => T,
+      construct: (Rdf4j#ConstructQuery) => T,
+      ask: Rdf4j#AskQuery => T) =
+    query match {
+      case qs: Rdf4j#SelectQuery => select(qs)
+      case qc: Rdf4j#ConstructQuery => construct(qc)
+      case qa: Rdf4j#AskQuery => ask(qa)
+    }
+
+  def getNode(solution: Rdf4j#Solution, v: String): Try[Rdf4j#Node] = {
+    val node = solution.getValue(v)
+    if (node == null)
+      Failure(VarNotFound("var " + v + " not found in BindingSet " + solution.toString))
+    else
+      Success(node)
+  }
+
+  def varnames(solution: Rdf4j#Solution): Set[String] = solution.getBindingNames.asScala.toSet
+
+  def solutionIterator(solutions: Rdf4j#Solutions): Iterator[Rdf4j#Solution] = solutions.iterator
+
+}

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jStore.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/Rdf4jStore.scala
@@ -1,0 +1,100 @@
+package org.w3.banana.rd4j
+
+import org.w3.banana._
+import org.eclipse.rdf4j.model._
+import org.eclipse.rdf4j.model.impl._
+import org.eclipse.rdf4j.model.util._
+import org.eclipse.rdf4j.query._
+import org.eclipse.rdf4j.query.impl.TupleQueryResultBuilder
+import org.eclipse.rdf4j.repository.{RepositoryConnection, RepositoryResult}
+import org.w3.banana.rd4j.helper.QueryResultStreamIterator
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.StreamIterator
+import scala.util.Try
+
+class Rdf4jStore
+    extends RDFStore[Rdf4j, Try, RepositoryConnection]
+    with SparqlUpdate[Rdf4j, Try, RepositoryConnection] {
+
+  private val valueFactory: ValueFactory = SimpleValueFactory.getInstance()
+
+  /* Transactor */
+
+  def r[T](conn: RepositoryConnection, body: => T): Try[T] = ???
+
+  def rw[T](conn: RepositoryConnection, body: => T): Try[T] = ???
+
+  /* SparqlEngine */
+
+  /**
+   * Watch out connection is not closed here and neither is iterator.
+   * (what does that mean? please help out)
+   */
+  def executeSelect(conn: RepositoryConnection, query: Rdf4j#SelectQuery, bindings: Map[String, Rdf4j#Node]): Try[Rdf4j#Solutions] = Try {
+    val tupleQuery: TupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query.getSourceString)
+    bindings foreach { case (name, value) => tupleQuery.setBinding(name, value) }
+    val result = tupleQuery.evaluate()
+    val tupleQueryResult = QueryResults.distinctResults(result)
+    new QueryResultStreamIterator[BindingSet](tupleQueryResult).toStream
+  }
+
+  def executeConstruct(conn: RepositoryConnection,
+                       query: Rdf4j#ConstructQuery,
+                       bindings: Map[String, Rdf4j#Node]): Try[Rdf4j#Graph] = Try {
+    val graphQuery: GraphQuery = conn.prepareGraphQuery(QueryLanguage.SPARQL, query.getSourceString)
+    bindings foreach { case (name, value) => graphQuery.setBinding(name, value) }
+    val result: GraphQueryResult = graphQuery.evaluate()
+    val graph = new LinkedHashModel
+    while (result.hasNext) {
+      graph.add(result.next())
+    }
+    result.close()
+    graph
+  }
+
+  def executeAsk(conn: RepositoryConnection, query: Rdf4j#AskQuery, bindings: Map[String, Rdf4j#Node]): Try[Boolean] = Try {
+    val booleanQuery: BooleanQuery = conn.prepareBooleanQuery(QueryLanguage.SPARQL, query.getSourceString)
+    bindings foreach { case (name, value) => booleanQuery.setBinding(name, value) }
+    val result: Boolean = booleanQuery.evaluate()
+    result
+  }
+
+  def executeUpdate(conn: RepositoryConnection, query: Rdf4j#UpdateQuery, bindings: Map[String, Rdf4j#Node]): Try[Unit] = Try {
+    val updateQuery = conn.prepareUpdate(QueryLanguage.SPARQL, query.getSourceString)
+    bindings foreach { case (name, value) => updateQuery.setBinding(name, value) }
+    updateQuery.execute()
+  }
+
+  /* GraphStore */
+
+  def appendToGraph(conn: RepositoryConnection, uri: Rdf4j#URI, graph: Rdf4j#Graph): Try[Unit] = Try {
+    val triples = graph
+    conn.add(triples, uri)
+  }
+
+  def removeTriples(conn: RepositoryConnection, uri: Rdf4j#URI, tripleMatches: Iterable[TripleMatch[Rdf4j]]): Try[Unit] = Try {
+    val ts = tripleMatches.map {
+      case (s, p, o) =>
+        valueFactory.createStatement(s.asInstanceOf[Resource], p.asInstanceOf[IRI], o)
+    }
+    conn.remove(ts.asJava, uri)
+  }
+
+  def getGraph(conn: RepositoryConnection, uri: Rdf4j#URI): Try[Rdf4j#Graph] = Try {
+    val graph = new LinkedHashModel
+    val rr: RepositoryResult[Statement] = conn.getStatements(null, null, null, false, uri)
+    while (rr.hasNext) {
+      val s = rr.next()
+      graph.add(s)
+    }
+    rr.close()
+    graph
+  }
+
+  def removeGraph(conn: RepositoryConnection, uri: Rdf4j#URI): Try[Unit] = Try {
+    conn.remove(null: Resource, null, null, uri)
+  }
+
+}
+

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/helper/OptionConverter.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/helper/OptionConverter.scala
@@ -1,0 +1,28 @@
+package org.w3.banana.rd4j.helper
+
+import java.util.Optional
+
+/**
+  * Conversions between Scala Option and Java 8 Optional.
+  */
+object JavaOptionals {
+  implicit def toRichOption[T](opt: Option[T]): RichOption[T] = new RichOption[T](opt)
+  implicit def toRichOptional[T](optional: Optional[T]): RichOptional[T] = new RichOptional[T](optional)
+}
+
+class RichOption[T] (opt: Option[T]) {
+
+  /**
+    * Transform this Option to an equivalent Java Optional
+    */
+  def toOptional: Optional[T] = Optional.ofNullable(opt.getOrElse(null).asInstanceOf[T])
+}
+
+class RichOptional[T] (opt: Optional[T]) {
+
+  /**
+    * Transform this Optional to an equivalent Scala Option
+    */
+  def toOption: Option[T] = if (opt.isPresent) Some(opt.get()) else None
+}
+

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/helper/QueryResultStreamIterator.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/helper/QueryResultStreamIterator.scala
@@ -1,0 +1,12 @@
+package org.w3.banana.rd4j.helper
+
+import org.eclipse.rdf4j.query.QueryResult
+
+import scala.collection.{AbstractIterator, Iterator}
+import scala.collection.immutable.Stream
+
+final class QueryResultStreamIterator[+A](queryResults: QueryResult[A]) extends AbstractIterator[A] with Iterator[A] {
+  override def hasNext: Boolean = queryResults.hasNext
+
+  override def next(): A = queryResults.next()
+}

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jQueryResultsReader.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jQueryResultsReader.scala
@@ -1,0 +1,60 @@
+package org.w3.banana.rd4j.io
+
+import java.io._
+
+import org.eclipse.rdf4j.query.QueryResultHandlerException
+import org.eclipse.rdf4j.query.resultio.helpers.QueryResultCollector
+import org.eclipse.rdf4j.query.resultio.{QueryResultFormat, QueryResultIO, TupleQueryResultFormat}
+import org.w3.banana.io.{SparqlAnswerJson, SparqlAnswerXml, SparqlQueryResultsReader}
+import org.w3.banana.rd4j.Rdf4j
+
+import scala.collection.JavaConverters._
+import scala.util._
+
+private abstract class Rdf4jQueryResultsReader[S] extends SparqlQueryResultsReader[Rdf4j, S] {
+
+  def tupleFormat: TupleQueryResultFormat
+
+  def booleanFormat: QueryResultFormat
+
+  def read(in: InputStream, base: String) = {
+    val bytes: Array[Byte] = Iterator.continually(in.read).takeWhile((-1).!=).map(_.toByte).toArray
+    parse(bytes)
+  }
+
+  def parse(bytes: Array[Byte]): Try[Either[Rdf4j#Solutions, Boolean]] = Try {
+    val parser = QueryResultIO.createBooleanParser(booleanFormat)
+    val parsed = new QueryResultCollector
+    parser.setQueryResultHandler(new QueryResultCollector)
+    parser.parseQueryResult(new ByteArrayInputStream(bytes))
+    try {
+      Right(parsed.getBoolean)
+    } catch {
+      case e: QueryResultHandlerException =>
+        Left(parsed.getBindingSets.asScala.toStream)
+    }
+  }
+
+  def read(reader: Reader, base: String) = {
+    val queri = Iterator.continually(reader.read).takeWhile((-1).!=).map(_.toChar).toArray
+    parse(new String(queri).getBytes("UTF-8"))
+  }
+
+}
+
+object Rdf4jQueryResultsReader {
+
+  val queryResultsReaderJson: SparqlQueryResultsReader[Rdf4j, SparqlAnswerJson] =
+    new Rdf4jQueryResultsReader[SparqlAnswerJson] {
+      val tupleFormat = TupleQueryResultFormat.JSON
+      val booleanFormat = QueryResultIO.getBooleanParserFormatForMIMEType("application/sparql-results+json").get()
+    }
+
+  implicit val queryResultsReaderXml: SparqlQueryResultsReader[Rdf4j, SparqlAnswerXml] =
+    new Rdf4jQueryResultsReader[SparqlAnswerXml] {
+      val tupleFormat = TupleQueryResultFormat.SPARQL
+      val booleanFormat = QueryResultIO.getBooleanParserFormatForMIMEType("application/sparql-results+xml").get()
+    }
+
+}
+

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jRDFReader.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jRDFReader.scala
@@ -1,0 +1,78 @@
+package org.w3.banana.rd4j.io
+
+import java.io._
+import java.util.LinkedList
+
+import org.eclipse.rdf4j.model.impl.{LinkedHashModel, SimpleValueFactory}
+import org.eclipse.rdf4j.model.{Literal, Statement, ValueFactory}
+import org.w3.banana._
+import org.w3.banana.io._
+import org.w3.banana.rd4j.Rdf4j
+
+import scala.util._
+
+trait CollectorFix extends org.eclipse.rdf4j.rio.helpers.StatementCollector {
+
+  def ops: RDFOps[Rdf4j]
+
+  private val valueFactory: ValueFactory = SimpleValueFactory.getInstance()
+
+  override def handleStatement(st: Statement): Unit = st.getObject match {
+    case o: Literal if o.getDatatype == null && o.getLanguage == null =>
+      super.handleStatement(
+        valueFactory.createStatement(
+          st.getSubject,
+          st.getPredicate,
+          valueFactory.createLiteral(o.getLabel, ops.xsd.string)))
+    case other =>
+      super.handleStatement(st)
+  }
+
+}
+
+abstract class AbstractRdf4jReader[T] extends RDFReader[Rdf4j, Try, T] {
+
+  implicit def ops: RDFOps[Rdf4j]
+
+  def getParser(): org.eclipse.rdf4j.rio.RDFParser
+
+  def read(in: InputStream, base: String): Try[Rdf4j#Graph] = Try {
+    val parser = getParser()
+    val triples = new LinkedList[Statement]
+    val collector = new org.eclipse.rdf4j.rio.helpers.StatementCollector(triples) with CollectorFix {
+      val ops = AbstractRdf4jReader.this.ops
+    }
+    parser.setRDFHandler(collector)
+    parser.parse(in, base)
+    new LinkedHashModel(triples)
+  }
+
+  def read(reader: Reader, base: String): Try[Rdf4j#Graph] = Try {
+    val parser = getParser()
+    val triples = new LinkedList[Statement]
+    val collector = new org.eclipse.rdf4j.rio.helpers.StatementCollector(triples) with CollectorFix {
+      val ops = AbstractRdf4jReader.this.ops
+    }
+    parser.setRDFHandler(collector)
+    parser.parse(reader, base)
+    new LinkedHashModel(triples)
+  }
+
+}
+
+class Rdf4jTurtleReader(implicit val ops: RDFOps[Rdf4j]) extends AbstractRdf4jReader[Turtle] {
+  def getParser() = new org.eclipse.rdf4j.rio.turtle.TurtleParser
+}
+
+class Rdf4jRDFXMLReader(implicit val ops: RDFOps[Rdf4j]) extends AbstractRdf4jReader[RDFXML] {
+  def getParser() = new org.eclipse.rdf4j.rio.rdfxml.RDFXMLParser
+}
+
+/**
+ * Note: an issue with the com.github.jsonldjava is apparently that it
+ * loads the whole JSON file into memory, which is memory consumptive
+ */
+class Rdf4jJSONLDReader(implicit val ops: RDFOps[Rdf4j]) extends AbstractRdf4jReader[JsonLd] {
+  def getParser() = new org.eclipse.rdf4j.rio.jsonld.JSONLDParser
+}
+

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jRDFWriter.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jRDFWriter.scala
@@ -1,0 +1,51 @@
+package org.w3.banana.rd4j.io
+
+import java.io._
+
+import org.w3.banana.Prefix
+import org.w3.banana.io._
+import org.w3.banana.rd4j.{Rdf4j, Rdf4jOps}
+
+import scala.util._
+
+class Rdf4jRDFWriter[T](implicit
+  ops: Rdf4jOps,
+  rdf4jSyntax: Rdf4jSyntax[T]
+) extends RDFWriter[Rdf4j, Try, T] {
+
+  def write(graph: Rdf4j#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Rdf4j]]): Try[Unit] = Try {
+    val sWriter = rdf4jSyntax.rdfWriter(os, base)
+    prefixes.foreach(p => {
+      sWriter.handleNamespace(p.prefixName, p.prefixIri)
+    })
+    sWriter.startRDF()
+    ops.getTriples(graph) foreach sWriter.handleStatement
+    sWriter.endRDF()
+  }
+
+  def asString(graph: Rdf4j#Graph, base: String, prefixes: Set[Prefix[Rdf4j]]): Try[String] = Try {
+    val result = new StringWriter()
+    val sWriter = rdf4jSyntax.rdfWriter(result, base)
+    prefixes.foreach(p => {
+      sWriter.handleNamespace(p.prefixName, p.prefixIri)
+    })
+    sWriter.startRDF()
+    ops.getTriples(graph) foreach sWriter.handleStatement
+    sWriter.endRDF()
+    result.toString
+  }
+}
+
+class Rdf4jRDFWriterHelper(implicit ops: Rdf4jOps) {
+
+  implicit val rdfxmlWriter: RDFWriter[Rdf4j, Try, RDFXML] = new Rdf4jRDFWriter[RDFXML]
+
+  implicit val turtleWriter: RDFWriter[Rdf4j, Try, Turtle] = new Rdf4jRDFWriter[Turtle]
+
+  implicit val jsonldCompactedWriter: RDFWriter[Rdf4j, Try, JsonLdCompacted] = new Rdf4jRDFWriter[JsonLdCompacted]
+
+  implicit val jsonldExpandedWriter: RDFWriter[Rdf4j, Try, JsonLdExpanded] = new Rdf4jRDFWriter[JsonLdExpanded]
+
+  implicit val jsonldFlattenedWriter: RDFWriter[Rdf4j, Try, JsonLdFlattened] = new Rdf4jRDFWriter[JsonLdFlattened]
+
+}

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jSolutionsWriter.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jSolutionsWriter.scala
@@ -1,0 +1,54 @@
+package org.w3.banana.rd4j.io
+
+import java.io._
+
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriter
+import org.w3.banana._
+import org.w3.banana.io.{SparqlAnswerJson, SparqlAnswerXml}
+import org.w3.banana.rd4j.Rdf4j
+
+import scala.util._
+
+private abstract class Rdf4jSolutionsWriter[S] extends SparqlSolutionsWriter[Rdf4j, S] {
+
+  def writer(outputStream: OutputStream): TupleQueryResultWriter
+
+  def write(answers: Rdf4j#Solutions, os: OutputStream, base: String) = Try {
+    val sWriter = writer(os)
+    // sWriter.startQueryResult(answers.getBindingNames)
+    sWriter.startQueryResult(new java.util.ArrayList()) // <- yeah, probably wrong...
+    answers.foreach { answer => sWriter.handleSolution(answer) }
+    sWriter.endQueryResult()
+  }
+
+  def asString(answers: Rdf4j#Solutions, base: String) = Try {
+    // TODO this goes through the lossy outputstream in order to then
+    // recode a string, even though it does not really know what the
+    // required encoding is
+    val out = new ByteArrayOutputStream()
+    write(answers, out, base)
+    new String(out.toByteArray, "UTF-8")
+  }
+
+}
+
+
+object Rdf4jSolutionsWriter {
+
+  val solutionsWriterJson: SparqlSolutionsWriter[Rdf4j, SparqlAnswerJson] = new Rdf4jSolutionsWriter[SparqlAnswerJson] {
+
+    import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONWriter
+
+    def writer(outputStream: OutputStream): TupleQueryResultWriter = new SPARQLResultsJSONWriter(outputStream)
+
+  }
+
+  val solutionsWriterXml: SparqlSolutionsWriter[Rdf4j, SparqlAnswerXml] = new Rdf4jSolutionsWriter[SparqlAnswerXml] {
+
+    import org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLWriter
+
+    def writer(outputStream: OutputStream): TupleQueryResultWriter = new SPARQLResultsXMLWriter(outputStream)
+
+  }
+
+}

--- a/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jSyntax.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rd4j/io/Rdf4jSyntax.scala
@@ -1,0 +1,107 @@
+package org.w3.banana.rd4j.io
+
+import java.io.{OutputStream, Writer}
+import java.net.{URI => jURI}
+
+import org.eclipse.rdf4j.model.{IRI, Statement}
+import org.w3.banana.io._
+import org.eclipse.rdf4j.rio.RDFWriter
+import org.eclipse.rdf4j.rio.helpers.{JSONLDMode, JSONLDSettings}
+import org.eclipse.rdf4j.rio.jsonld.JSONLDWriter
+import org.eclipse.rdf4j.rio.rdfxml.{RDFXMLWriter => SRdfXmlWriter}
+import org.eclipse.rdf4j.rio.turtle.{TurtleWriter => STurtleWriter}
+
+/** Typeclass that reflects a Rdf4j String that can be used to construct an [[RDFWriter]]. */
+trait Rdf4jSyntax[T] {
+  def rdfWriter(os: OutputStream, base: String): RDFWriter
+  def rdfWriter(wr: Writer, base: String): RDFWriter
+}
+
+object Rdf4jSyntax {
+
+  implicit val RDFXML: Rdf4jSyntax[RDFXML] = new Rdf4jSyntax[RDFXML] {
+    import org.w3.banana.rd4j.Rdf4j.ops._
+    // Rdf4j's parser does not handle relative URI, but let us override the behavior :-)
+    def rdfWriter(os: OutputStream, base: String) = new SRdfXmlWriter(os) {
+      val baseUri = URI(base)
+      override def handleStatement(st: Statement) = {
+        super.handleStatement(st.relativizeAgainst(baseUri))
+      }
+    }
+
+    def rdfWriter(wr: Writer, base: String) = new SRdfXmlWriter(wr) {
+      val baseUri = URI(base)
+      override def handleStatement(st: Statement) = {
+        super.handleStatement(st.relativizeAgainst(baseUri))
+      }
+    }
+  }
+
+  implicit val Turtle: Rdf4jSyntax[Turtle] = new Rdf4jSyntax[Turtle] {
+    import org.w3.banana.rd4j.Rdf4j.ops._
+    // Rdf4j's parser does not handle relative URI, but let us override the behavior :-)
+    def relativize(uri: IRI, baseURI: jURI): Either[IRI, String] = {
+      val juri = new jURI(uri.toString)
+      val relative = baseURI.relativize(juri).toString
+
+      if (relative.length > 0) Left(makeUri(relative)) else Right(relative)
+    }
+
+    def rdfWriter(os: OutputStream, base: String) = new STurtleWriter(os) {
+      val baseUri = new jURI(base)
+
+      override def writeURI(uri: IRI): Unit = {
+        val uriToWrite = relativize(uri, baseUri)
+        uriToWrite.fold(
+          super.writeURI,
+          s => writer.write("<" + s + ">")
+        )
+      }
+    }
+
+    def rdfWriter(wr: Writer, base: String) = new STurtleWriter(wr) {
+      val baseUri = new jURI(base)
+
+      override def writeURI(uri: IRI): Unit = {
+        val uriToWrite = relativize(uri, baseUri)
+        uriToWrite.fold(
+          super.writeURI,
+          s => writer.write("<" + s + ">")
+        )
+      }
+    }
+  }
+
+  implicit val jsonLdCompacted: Rdf4jSyntax[JsonLdCompacted] = jsonldSyntax(JSONLDMode.COMPACT)
+
+  implicit val jsonLdExpanded: Rdf4jSyntax[JsonLdExpanded] = jsonldSyntax(JSONLDMode.EXPAND)
+
+  implicit val jsonLdFlattened: Rdf4jSyntax[JsonLdFlattened] = jsonldSyntax(JSONLDMode.FLATTEN)
+
+  private def jsonldSyntax[T](mode: JSONLDMode) = new Rdf4jSyntax[T] {
+    import org.w3.banana.rd4j.Rdf4j.ops._
+
+    def rdfWriter(os: OutputStream, base: String) = {
+      val baseUri = URI(base)
+      val writer = new JSONLDWriter(os) {
+        override def handleStatement(st: Statement) = {
+          super.handleStatement(st.relativizeAgainst(baseUri))
+        }
+      }
+      writer.getWriterConfig().set(JSONLDSettings.JSONLD_MODE, mode)
+      writer
+    }
+    def rdfWriter(wr: Writer, base: String) = {
+      val baseUri = URI(base)
+      val writer = new JSONLDWriter(wr)  {
+        override def handleStatement(st: Statement) = {
+          super.handleStatement(st.relativizeAgainst(baseUri))
+        }
+      }
+      writer.getWriterConfig().set(JSONLDSettings.JSONLD_MODE, mode)
+      writer
+    }
+  }
+
+}
+

--- a/rdf4j/src/test/scala/org/w3/banana/rdf4j/Rdf4jGraphStoreTest.scala
+++ b/rdf4j/src/test/scala/org/w3/banana/rdf4j/Rdf4jGraphStoreTest.scala
@@ -1,0 +1,32 @@
+package org.w3.banana.rdf4j
+
+import org.eclipse.rdf4j.repository.RepositoryConnection
+import org.eclipse.rdf4j.repository.sail.SailRepository
+import org.eclipse.rdf4j.sail.memory.MemoryStore
+import org.w3.banana._
+import org.w3.banana.rd4j.Rdf4j
+import org.w3.banana.util.tryInstances._
+
+import scala.util.Try
+
+
+abstract class Rdf4jGraphStoreTest(conn: RepositoryConnection) extends GraphStoreTest[Rdf4j, Try, RepositoryConnection](conn) {
+
+  import ops._
+
+  /*"adding a named graph should not pollute the default graph" in {
+    val defaultGraph =
+      conn.appendToGraph(makeUri("http://example.com/foo"), graph).flatMap { _ =>
+        conn.getGraph(null.asInstanceOf[Rdf4j#URI])
+      }.get
+    defaultGraph should have size (0)
+  }*/
+
+}
+
+class Rdf4jMemoryGraphStoreTest extends Rdf4jGraphStoreTest({
+  val repo = new SailRepository(new MemoryStore)
+  repo.init()
+  repo.getConnection()
+})
+

--- a/rdf4j/src/test/scala/org/w3/banana/rdf4j/Rdf4jOpsTest.scala
+++ b/rdf4j/src/test/scala/org/w3/banana/rdf4j/Rdf4jOpsTest.scala
@@ -1,0 +1,38 @@
+package org.w3.banana.rdf4j
+
+import org.w3.banana.{GraphTest, GraphUnionTest, MGraphTest, PointedGraphTest, RDFOpsTest}
+import org.w3.banana.rd4j.Rdf4j
+
+class Rdf4jOpsTest extends RDFOpsTest[Rdf4j]
+
+class Rdf4jGraphTest extends GraphTest[Rdf4j]
+
+class Rdf4jMGraphTest extends MGraphTest[Rdf4j]
+
+import org.w3.banana.isomorphism._
+
+class Rdf4jIsomorphismTest extends IsomorphismTest[Rdf4j]
+
+class Rdf4jGraphUnionTest extends GraphUnionTest[Rdf4j]
+
+class Rdf4jPointedGraphTest extends PointedGraphTest[Rdf4j]
+
+import org.w3.banana.diesel._
+
+class Rdf4jDieselGraphConstructTest extends DieselGraphConstructTest[Rdf4j]
+
+class Rdf4jDieselGraphExplorationTest extends DieselGraphExplorationTest[Rdf4j]
+
+class Rdf4jDieselOwlPrimerTest extends DieselOwlPrimerTest[Rdf4j]
+
+import org.w3.banana.binder._
+
+class Rdf4jCommonBindersTest extends CommonBindersTest[Rdf4j]
+
+class Rdf4jRecordBinderTest extends RecordBinderTest[Rdf4j]
+
+class Rdf4jCustomBinderTest extends CustomBindersTest[Rdf4j]
+
+import org.w3.banana.syntax._
+
+class Rdf4jUriSyntaxTest extends UriSyntaxTest[Rdf4j]

--- a/rdf4j/src/test/scala/org/w3/banana/rdf4j/Rdf4jSparqlEngineTest.scala
+++ b/rdf4j/src/test/scala/org/w3/banana/rdf4j/Rdf4jSparqlEngineTest.scala
@@ -1,0 +1,24 @@
+package org.w3.banana.rdf4j
+
+import org.eclipse.rdf4j.repository.RepositoryConnection
+import org.eclipse.rdf4j.repository.sail.SailRepository
+import org.eclipse.rdf4j.sail.memory.MemoryStore
+import org.w3.banana._
+import org.w3.banana.rd4j.Rdf4j
+import org.w3.banana.util.tryInstances._
+
+class Rdf4jSparqlEngineTest extends SparqlEngineTest[Rdf4j, RepositoryConnection]({
+  val repo = new SailRepository(new MemoryStore)
+  //    val d = java.nio.file.Files.createTempDirectory("rdf4j-")
+  //    val repo = new SailRepository((new NativeStore(d.toFile, "spoc,posc")))
+  repo.init()
+  repo.getConnection()
+})
+
+class Rdf4jSparqlEngineUpdateTest extends SparqlUpdateEngineTest[Rdf4j, RepositoryConnection]({
+  val repo = new SailRepository(new MemoryStore)
+  //    val d = java.nio.file.Files.createTempDirectory("rdf4j-")
+  //    val repo = new SailRepository((new NativeStore(d.toFile, "spoc,posc")))
+  repo.init()
+  repo.getConnection()
+})

--- a/rdf4j/src/test/scala/org/w3/banana/rdf4j/Rdf4jSparqlGraphTest.scala
+++ b/rdf4j/src/test/scala/org/w3/banana/rdf4j/Rdf4jSparqlGraphTest.scala
@@ -1,0 +1,10 @@
+package org.w3.banana.rdf4j
+
+import org.w3.banana._
+import org.w3.banana.io._
+import org.w3.banana.rd4j.Rdf4j
+import org.w3.banana.rd4j.io.Rdf4jSolutionsWriter
+
+class Rdf4jSparqlGraphTestJson(implicit sparqlWriter: SparqlSolutionsWriter[Rdf4j, SparqlAnswerJson] = Rdf4jSolutionsWriter.solutionsWriterJson) extends SparqlGraphTest[Rdf4j, SparqlAnswerJson]
+
+class Rdf4jSparqlGraphTestXml(implicit sparqlWriter: SparqlSolutionsWriter[Rdf4j, SparqlAnswerXml] = Rdf4jSolutionsWriter.solutionsWriterXml) extends SparqlGraphTest[Rdf4j, SparqlAnswerXml]

--- a/rdf4j/src/test/scala/org/w3/banana/rdf4j/io/Rdf4jSerialisationTests.scala
+++ b/rdf4j/src/test/scala/org/w3/banana/rdf4j/io/Rdf4jSerialisationTests.scala
@@ -1,0 +1,23 @@
+package org.w3.banana.rdf4j.io
+
+import org.w3.banana.io._
+import org.w3.banana.rd4j.Rdf4j
+import org.w3.banana.util.tryInstances._
+
+import scala.util.Try
+
+class Rdf4jTurtleTests extends TurtleTestSuite[Rdf4j, Try]
+
+class Rdf4jPrefixTest extends PrefixTestSuite[Rdf4j, Try]
+
+class Rdf4jNTripleReaderTestSuite extends NTriplesReaderTestSuite[Rdf4j]
+
+class Rdf4jNTripleWriterTestSuite extends NTriplesWriterTestSuite[Rdf4j]
+
+class Rdf4jRdfXMLTests extends RdfXMLTestSuite[Rdf4j, Try]
+
+class Rdf4jJsonLDCompactedTests extends JsonLDTestSuite[Rdf4j, Try, JsonLdCompacted]
+
+class Rdf4jJsonLDExpandedTests extends JsonLDTestSuite[Rdf4j, Try, JsonLdExpanded]
+
+class Rdf4jJsonLDFlattened extends JsonLDTestSuite[Rdf4j, Try, JsonLdExpanded]


### PR DESCRIPTION
To my mind  we should go with the time and provide a RDF4J implementation. This could lead to a banan-rdf SHACL  adapter and other things. It came out of an experiment, but I quickly recognized that there was not much to be changed. As all tests run, I want to contribute it.

I tested it with version 2.5.4 and 3.0.0.

A small change to the NTriple test suite had to be made...