### PR TITLE
release under net.bblfish to sonatype 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ banana-rdf
 The current published version 0.8.5-SNAPSHOT for scala 2.13 is to be found on the Sonatype repository under groupId [net/bblfish/rdf/](https://oss.sonatype.org/content/repositories/snapshots/net/bblfish/rdf/).
 
 ```scala
-val banana = (name: String) => "org.w3" %% name % "0.8.5-SNAPSHOT" excludeAll (ExclusionRule(organization = "org.scala-stm"))
+val banana = (name: String) => "net.bblfish.rdf" %% name % "0.8.5-SNAPSHOT" excludeAll (ExclusionRule(organization = "org.scala-stm"))
 
 //choose the packages you need for your dependencies
 val bananaDeps = Seq("banana", "banana-rdf", "banana-rdf4j").map(banana)

--- a/README.md
+++ b/README.md
@@ -3,14 +3,10 @@ banana-rdf
 
 [![Build Status](https://secure.travis-ci.org/w3c/banana-rdf.png)](http://travis-ci.org/w3c/banana-rdf) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/w3c/banana-rdf?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-The current published version 0.8.4 for scala 2.12 is to be found on the [http://bblfish.net/work/repo/releases](http://bblfish.net/work/repo/releases) repository.
+The current published version 0.8.5-SNAPSHOT for scala 2.13 is to be found on the Sonatype repository under groupId [net/bblfish/rdf/](https://oss.sonatype.org/content/repositories/snapshots/net/bblfish/rdf/).
 
 ```scala
-val banana = (name: String) => "org.w3" %% name % "0.8.4" excludeAll (ExclusionRule(organization = "org.scala-stm"))
-
-//add the bblfish-snapshots repository to the resolvers
-
-resolvers += "bblfish-snapshots" at "http://bblfish.net/work/repo/releases"
+val banana = (name: String) => "org.w3" %% name % "0.8.5-SNAPSHOT" excludeAll (ExclusionRule(organization = "org.scala-stm"))
 
 //choose the packages you need for your dependencies
 val bananaDeps = Seq("banana", "banana-rdf", "banana-rdf4j").map(banana)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ val banana = (name: String) => "net.bblfish.rdf" %% name % "0.8.5-SNAPSHOT" excl
 //choose the packages you need for your dependencies
 val bananaDeps = Seq("banana", "banana-rdf", "banana-rdf4j").map(banana)
 ```
+Also for snapshot releases you need to add the sonatype resolver 
+```scala
+resolvers += Resolver.sonatypeRepo("snapshots")
+```
 
 An RDF library in Scala
 -----------------------

--- a/build.sbt
+++ b/build.sbt
@@ -1,53 +1,34 @@
-import sbt.Keys._
-import sbt._
+import sbt.Keys.{publishMavenStyle, _}
+import sbt.{url, _}
 import Dependencies._
-import sbtcrossproject.CrossPlugin.autoImport.{ crossProject, CrossType }
+import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 
-lazy val pomSettings = Seq(
-  pomIncludeRepository := { _ => false},
-  pomExtra :=
-    <url>https://github.com/w3c/banana-rdf</url>
-      <developers>
-        <developer>
-          <id>betehess</id>
-          <name>Alexandre Bertails</name>
-          <url>http://bertails.org/</url>
-        </developer>
-        <developer>
-          <id>InTheNow</id>
-          <name>Alistair Johnson</name>
-          <url>https://github.com/inthenow</url>
-        </developer>
-        <developer>
-          <id>bblfish</id>
-          <name>Henry Story</name>
-          <url>http://bblfish.net/</url>
-        </developer>
-      </developers>
-      <scm>
-        <url>git@github.com:w3c/banana-rdf.git</url>
-        <connection>scm:git:git@github.com:w3c/banana-rdf.git</connection>
-      </scm>
-  ,
-  licenses +=("W3C", url("http://opensource.org/licenses/W3C"))
-)
 
 //sbt -Dbanana.publish=bblfish.net:/home/hjs/htdocs/work/repo/
 //sbt -Dbanana.publish=bintray
-lazy val publicationSettings = pomSettings ++ {
+lazy val publicationSettings = {
   val pubre = """([^:]+):([^:]+)""".r
   Option(System.getProperty("banana.publish")) match {
     case Some("bintray") | None => Seq(
-// removed due to issue https://github.com/typesafehub/dbuild/issues/158
-//      publishTo := {
-//        val nexus = "https://oss.sonatype.org/"
-//        if (isSnapshot.value)
-//          Some("snapshots" at nexus + "content/repositories/snapshots")
-//        else
-//          Some("releases" at nexus + "service/local/staging/deploy/maven2")
-//      },
-//      releasePublishArtifactsAction := PgpKeys.publishSigned.value,
-//      Test / publishArtifact  := false
+      sonatypeProfileName := "net.bblfish",
+      publishTo := sonatypePublishToBundle.value,
+
+      // To sync with Maven central, you need to supply the following information:
+      publishMavenStyle := true,
+
+      // Open-source license of your choice
+      licenses +=("W3C", url("http://opensource.org/licenses/W3C")),
+      homepage := Some(url("https://github.com/banana-rdf/banana-rdf")),
+      scmInfo := Some(
+        ScmInfo(
+          url("https://github.com/banana-rdf/banana-rdf"),
+          "scm:git@github.com:banana-rdf/banana-rdf.git"
+        )
+      ),
+      developers := List(
+        Developer(id="bblfish", name="Henry Story", email="henry.story@bblfish.net", url=url("https://bblfish.net")),
+        Developer(id="bertails", name="Alexandre Bertails", email="alexandre@bertails.org", url=url("http://www.bertails.org/"))
+      )
     )
     case Some(pubre(host, path)) =>
       Seq(
@@ -66,7 +47,7 @@ lazy val publicationSettings = pomSettings ++ {
 }
 
 lazy val commonSettings = publicationSettings ++ scalariformSettings ++ Seq(
-  organization := "org.w3",
+  organization := "net.bblfish.rdf",
   scalaVersion := "2.13.3",
   resolvers += "apache-repo-releases" at "https://repository.apache.org/content/repositories/releases/",
   fork := false,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,8 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
-
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
+//addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
 /**
   * Bintray pluging
@@ -72,3 +70,16 @@ addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
   * @see https://github.com/rtimush/sbt-updates
   */
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.2")
+
+/**
+ * sbtsonatype plugin used to publish artifact to maven central via sonatype nexus
+ * @see https://github.com/xerial/sbt-sonatype
+ */
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
+
+
+  /**
+  * plugin used to sign the artifcat with pgp keys
+  * @see https://github.com/sbt/sbt-pgp
+  */
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
As we no longer have anyone working at W3C it will be easier to publish code under a new groupId to sonatype. The first release is now here: https://oss.sonatype.org/content/repositories/snapshots/net/bblfish/rdf/