### PR TITLE
upgrade libs and fix deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jdk:
   - oraclejdk11
 
 scala:
-  - 2.13.3
+  - 2.13.5
 
 branches:
   only:

--- a/build.sbt
+++ b/build.sbt
@@ -48,12 +48,13 @@ lazy val publicationSettings = {
 
 lazy val commonSettings = publicationSettings ++ scalariformSettings ++ Seq(
   organization := "net.bblfish.rdf",
-  scalaVersion := "2.13.5", //"3.0.0-RC2",
+  scalaVersion := "3.0.0-RC2",
   resolvers += "apache-repo-releases" at "https://repository.apache.org/content/repositories/releases/",
   fork := false,
   Test / parallelExecution := false,
   offline := true,
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions,higherKinds"),
+   // "-source:3.0-migration"),
   Compile / doc / scalacOptions := Seq("-groups", "-implicits"),
   description := "RDF framework for Scala",
   startYear := Some(2012),

--- a/build.sbt
+++ b/build.sbt
@@ -48,13 +48,13 @@ lazy val publicationSettings = {
 
 lazy val commonSettings = publicationSettings ++ scalariformSettings ++ Seq(
   organization := "net.bblfish.rdf",
-  scalaVersion := "3.0.0-RC2",
+  scalaVersion := "2.13.5", //"3.0.0-RC2",
   resolvers += "apache-repo-releases" at "https://repository.apache.org/content/repositories/releases/",
   fork := false,
   Test / parallelExecution := false,
   offline := true,
   scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions,higherKinds"),
-  scalacOptions in(Compile, doc) := Seq("-groups", "-implicits"),
+  Compile / doc / scalacOptions := Seq("-groups", "-implicits"),
   description := "RDF framework for Scala",
   startYear := Some(2012),
   updateOptions := updateOptions.value.withCachedResolution(true) //to speed up dependency resolution
@@ -112,14 +112,15 @@ lazy val plantain = crossProject(JSPlatform, JVMPlatform)
   .in(file("plantain"))
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(akkaHttpCore, rdf4jRioTurtle, jsonldJava)
+    libraryDependencies ++= Seq(rdf4jRioTurtle, jsonldJava),
+    libraryDependencies += akkaHttpCore.withDottyCompat(scalaVersion.value)
   )
   .settings(name := "banana-plantain")
   .dependsOn(rdf, ntriples, rdfTestSuite % "test->compile")
 
 lazy val plantainJS = plantain.js
 lazy val plantainJVM = plantain.jvm.settings(
-  libraryDependencies += akka
+  libraryDependencies += akka.withDottyCompat(scalaVersion.value)
 )
 
 lazy val jena = Project("jena", file("jena"))
@@ -175,7 +176,7 @@ commonSettings
 
 enablePlugins(ScalaUnidocPlugin)
 
-unidocProjectFilter in ( ScalaUnidoc, unidoc ) :=
+ ScalaUnidoc / unidoc / unidocProjectFilter :=
     inAnyProject -- inProjects( ntriplesJS, plantainJS, rdfJS, rdfTestSuiteJS )
 
 addCommandAlias("validate", ";compile;test;runExamples")

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val publicationSettings = {
 
 lazy val commonSettings = publicationSettings ++ scalariformSettings ++ Seq(
   organization := "net.bblfish.rdf",
-  scalaVersion := "2.13.5",
+  scalaVersion := "3.0.0-RC2",
   resolvers += "apache-repo-releases" at "https://repository.apache.org/content/repositories/releases/",
   fork := false,
   Test / parallelExecution := false,
@@ -73,7 +73,7 @@ lazy val rdf = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies += scalaz.value
   )
   .jvmSettings(
-    libraryDependencies ++= Seq(jodaTime, jodaConvert)
+    libraryDependencies ++= Seq(jodaTime, jodaConvert),
   )
 
 lazy val rdfJS = rdf.js
@@ -112,7 +112,7 @@ lazy val plantain = crossProject(JSPlatform, JVMPlatform)
   .in(file("plantain"))
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= Seq(akkaHttpCore, rdf4jRioTurtle, jsonldJava, java8Compat)
+    libraryDependencies ++= Seq(akkaHttpCore, rdf4jRioTurtle, jsonldJava)
   )
   .settings(name := "banana-plantain")
   .dependsOn(rdf, ntriples, rdfTestSuite % "test->compile")

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import sbt.Keys.{publishMavenStyle, _}
-import sbt.{url, _}
+import sbt.{CrossVersion, url, _}
 import Dependencies._
 import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 
@@ -48,7 +48,7 @@ lazy val publicationSettings = {
 
 lazy val commonSettings = publicationSettings ++ scalariformSettings ++ Seq(
   organization := "net.bblfish.rdf",
-  scalaVersion := "3.0.0-RC2",
+  scalaVersion := "2.13.5", //"3.0.0-RC2",
   resolvers += "apache-repo-releases" at "https://repository.apache.org/content/repositories/releases/",
   fork := false,
   Test / parallelExecution := false,
@@ -114,14 +114,14 @@ lazy val plantain = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings: _*)
   .settings(
     libraryDependencies ++= Seq(rdf4jRioTurtle, jsonldJava),
-    libraryDependencies += akkaHttpCore.withDottyCompat(scalaVersion.value)
+    libraryDependencies += akkaHttpCore
   )
   .settings(name := "banana-plantain")
   .dependsOn(rdf, ntriples, rdfTestSuite % "test->compile")
 
 lazy val plantainJS = plantain.js
 lazy val plantainJVM = plantain.jvm.settings(
-  libraryDependencies += akka.withDottyCompat(scalaVersion.value)
+  libraryDependencies += akka
 )
 
 lazy val jena = Project("jena", file("jena"))

--- a/jena/src/main/scala/org/w3/banana/jena/JenaModule.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaModule.scala
@@ -63,7 +63,7 @@ with XmlQueryResultsReaderModule {
 
   implicit val ntriplesWriter: RDFWriter[Jena, Try, NTriples] = new NTriplesWriter[Jena]
 
-  implicit val jsonldReader: RDFReader[Rdf, Try, JsonLd] = JenaRDFReader.jsonLdReader
+  implicit val jsonldReader: RDFReader[Rdf, Try, JsonLd] = JenaRDFReader.jsonLdReader()
 
   implicit val jsonSolutionsWriter: SparqlSolutionsWriter[Jena, SparqlAnswerJson] =
     JenaSolutionsWriter.solutionsWriterJson

--- a/jena/src/main/scala/org/w3/banana/jena/JenaOps.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaOps.scala
@@ -5,7 +5,7 @@ import org.apache.jena.graph.{Graph => JenaGraph, Node => JenaNode, Triple => Je
 import org.apache.jena.rdf.model.{Literal => JenaLiteral, Seq => _}
 import org.w3.banana._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class JenaOps extends RDFOps[Jena] with JenaMGraphOps with DefaultURIOps[Jena] {
 
@@ -135,7 +135,7 @@ class JenaOps extends RDFOps[Jena] with JenaMGraphOps with DefaultURIOps[Jena] {
       funConcrete(nodeMatch.asInstanceOf[JenaNode])
 
   def find(graph: Jena#Graph, subject: Jena#NodeMatch, predicate: Jena#NodeMatch, objectt: Jena#NodeMatch): Iterator[Jena#Triple] = {
-    graph.find(subject, predicate, objectt).asScala.toIterator
+    graph.find(subject, predicate, objectt).asScala
   }
 
   // graph union

--- a/jena/src/main/scala/org/w3/banana/jena/JenaSparqlOps.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaSparqlOps.scala
@@ -8,7 +8,7 @@ import org.apache.jena.update.UpdateFactory
 import org.w3.banana.SparqlOps.withPrefixes
 import org.w3.banana._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util._
 import scala.unchecked
 

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaAnswerOutput.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaAnswerOutput.scala
@@ -1,25 +1,25 @@
 package org.w3.banana.jena.io
 
-import org.apache.jena.sparql.resultset.{ JSONOutput, OutputFormatter, XMLOutput }
+import org.apache.jena.riot.resultset.ResultSetLang
 import org.w3.banana.io._
 
 /**
  * typeclass for serialising special
  */
 trait JenaAnswerOutput[T] {
-  def formatter: OutputFormatter
+  def formatter: org.apache.jena.riot.Lang
 }
 
 object JenaAnswerOutput {
 
   implicit val Json: JenaAnswerOutput[SparqlAnswerJson] =
     new JenaAnswerOutput[SparqlAnswerJson] {
-      def formatter = new JSONOutput()
+      def formatter =  ResultSetLang.SPARQLResultSetJSON
     }
 
   implicit val XML: JenaAnswerOutput[SparqlAnswerXml] =
     new JenaAnswerOutput[SparqlAnswerXml] {
-      def formatter = new XMLOutput()
+      def formatter = ResultSetLang.SPARQLResultSetXML
     }
 
 }

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaQueryResultsReader.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaQueryResultsReader.scala
@@ -1,12 +1,16 @@
 package org.w3.banana.jena.io
 
-import java.io.{ InputStream, Reader }
+import org.apache.jena.riot.ResultSetMgr
+import org.apache.jena.riot.resultset.ResultSetLang
+import org.apache.jena.riot.resultset.rw.ResultsReader
 
+import java.io.{InputStream, Reader}
 import org.w3.banana._
 import org.w3.banana.io.SparqlQueryResultsReader
 import org.w3.banana.jena.Jena
 import org.w3.banana.io._
-import org.apache.jena.sparql.resultset.{ JSONInput, SPARQLResult, XMLInput }
+import org.apache.jena.sparql.resultset.{JSONInput, SPARQLResult, XMLInput}
+
 import scala.util._
 
 abstract private class JenaQueryResultsReader[S] extends SparqlQueryResultsReader[Jena, S] {
@@ -24,7 +28,11 @@ abstract private class JenaQueryResultsReader[S] extends SparqlQueryResultsReade
     }
   }
 
-  def read(reader: Reader, base: String) = ???
+  /**
+   * Note: this is not implemented as Jena does all parsing with InputStreams, so a conversion would
+   * be wasteful
+   **/
+  def read(reader: Reader, base: String): Try[Either[Jena#Solutions, Boolean]] = ???
 
 }
 
@@ -34,12 +42,14 @@ object JenaQueryResultsReader {
 
   implicit val queryResultsReaderJson: SparqlQueryResultsReader[Jena, SparqlAnswerJson] =
     new JenaQueryResultsReader[SparqlAnswerJson] {
-      def parse(in: InputStream) = JSONInput.make(in)
+      def parse(in: InputStream): SPARQLResult =
+        new SPARQLResult(ResultSetMgr.read(in,ResultSetLang.SPARQLResultSetJSON))
     }
 
   implicit val queryResultsReaderXml: SparqlQueryResultsReader[Jena, SparqlAnswerXml] =
     new JenaQueryResultsReader[SparqlAnswerXml] {
-      def parse(in: InputStream) = XMLInput.make(in)
+      def parse(in: InputStream): SPARQLResult =
+        new SPARQLResult(ResultSetMgr.read(in,ResultSetLang.SPARQLResultSetXML))
     }
 
 }

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaSolutionsWriter.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaSolutionsWriter.scala
@@ -1,7 +1,11 @@
 package org.w3.banana.jena.io
 
 import java.io._
-import org.w3.banana._, io._, jena._
+import org.w3.banana._
+import io._
+import jena._
+import org.apache.jena.riot.ResultSetMgr
+
 import scala.util._
 
 object JenaSolutionsWriter {
@@ -12,13 +16,13 @@ object JenaSolutionsWriter {
   ): SparqlSolutionsWriter[Jena, T] = new SparqlSolutionsWriter[Jena, T] {
 
     def write(answers: Jena#Solutions, os: OutputStream, base: String) = Try {
-      jenaSparqlSyntax.formatter.format(os, answers)
+      ResultSetMgr.write(os,answers,jenaSparqlSyntax.formatter)
     }
 
     def asString(answers: Jena#Solutions, base: String): Try[String] = Try {
       val result = new ByteArrayOutputStream()
-      jenaSparqlSyntax.formatter.format(result, answers)
-      answers.toString
+      ResultSetMgr.write(result, answers, jenaSparqlSyntax.formatter)
+      result.toString
     }
   }
 

--- a/jena/src/test/scala/org/w3/banana/jena/JenaFusekiSparqlTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaFusekiSparqlTest.scala
@@ -26,14 +26,14 @@ class JenaFusekiSparqlTest extends AnyFlatSpec
    * Start Fuseki server
    */
   override def beforeAll(): Unit = {
-    server.start
+    server.start()
   }
 
   /**
    * Stop server
    */
   override def afterAll(): Unit = {
-    server.stop
+    server.stop()
   }
 
   "The repository" must "contain person 'Morgana'" in {
@@ -73,7 +73,7 @@ class JenaFusekiSparqlTest extends AnyFlatSpec
       """.stripMargin).get
 
     val client = new URL("http://localhost:3030/ds/query")
-    val results = client.executeSelect(selectQuery).get.iterator.to(Iterable)
+    val results = client.executeSelect(selectQuery).get.iterator().to(Iterable)
     val result = results.map(
       row => row("firstName").get
     )

--- a/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesReader.scala
+++ b/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesReader.scala
@@ -115,7 +115,7 @@ object  NTriplesParser {
       case Failure(other) => throw other // we break on first failure
       case Success(_) => true
     }
-    ntparser.ops.makeGraph(filteredIterator.map(_.get).toIterable)
+    ntparser.ops.makeGraph(filteredIterator.map(_.get).iterator.to(Iterable))
   }
 
 
@@ -217,7 +217,7 @@ class NTriplesParser[Rdf <: RDF](reader: Reader,
    * The initial '<' has already been read
    */
   @tailrec
-  private[io] final def parseIRI(iribuf: mutable.StringBuilder = newBuilder): Rdf#URI = {
+  private[io] final def parseIRI(iribuf: mutable.StringBuilder = new StringBuilder()): Rdf#URI = {
      read() match {
       case -1 => throw EOF("unexpected end of stream reading URI starting with '" + iribuf.toString() + "'")
       case '>' => URI(iribuf.toString())
@@ -228,7 +228,7 @@ class NTriplesParser[Rdf <: RDF](reader: Reader,
   }
 
   @tailrec
-  private def readN(i: Int, buf: StringBuilder = newBuilder): String = {
+  private def readN(i: Int, buf: StringBuilder = new StringBuilder()): String = {
     if (i <= 0) buf.toString
     else read() match {
       case -1 => throw EOF("reached end of stream while trying to readN chars")
@@ -236,9 +236,9 @@ class NTriplesParser[Rdf <: RDF](reader: Reader,
     }
   }
 
-  private def parseShortHex(): Char = hexVal(readN(4).toCharArray)
+  private def parseShortHex(): Char = hexVal(readN(4).toIndexedSeq)
 
-  private def parseLongHex(): Char = hexVal(readN(8).toCharArray)
+  private def parseLongHex(): Char = hexVal(readN(8).toIndexedSeq)
 
   private def parseIRIQuotedChar(): Char =
     read() match {
@@ -263,7 +263,7 @@ class NTriplesParser[Rdf <: RDF](reader: Reader,
     }
 
 
-  private[io] def parsePlainLiteral(uribuf: mutable.StringBuilder = newBuilder): String =
+  private[io] def parsePlainLiteral(uribuf: mutable.StringBuilder = new StringBuilder()): String =
     read() match {
       case -1   => throw EOF("end of string Literal before end of quotation")
       case '"'  => uribuf.toString() //closing quote
@@ -289,7 +289,7 @@ class NTriplesParser[Rdf <: RDF](reader: Reader,
     }
   }
   private def parseLang(): Rdf#Lang = {
-    val buf = newBuilder
+    val buf = new StringBuilder()
     @tailrec
     def lang(): String = {
       read() match {
@@ -364,7 +364,7 @@ class NTriplesParser[Rdf <: RDF](reader: Reader,
     if (nc != ':') throw Error(nc,"bnode must start with _:")
     else tryRead { c =>
       if (blank_node_label_first_char(c)) {
-        parseBnodeLabel(newBuilder.append(c))
+        parseBnodeLabel(new StringBuilder().append(c))
       } else {
         throw Error(c,s"blank node starts with illegal character in first position 'x0${Integer.toHexString(c)}'")
       }

--- a/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesReader.scala
+++ b/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesReader.scala
@@ -390,7 +390,7 @@ class NTriplesParser[Rdf <: RDF](reader: Reader,
     }
   }
 
-  private def endOfSentence(): Unit = read match {
+  private def endOfSentence(): Unit = read() match {
     case -1 => throw EOF("was still searching for '.'")
     case '.' => ()
     case c if whitespace(c) => endOfSentence()

--- a/plantain/js/src/main/scala/org/w3/banana/plantain/PlantainMGraphOps.scala
+++ b/plantain/js/src/main/scala/org/w3/banana/plantain/PlantainMGraphOps.scala
@@ -10,13 +10,13 @@ trait PlantainMGraphOps extends MGraphOps[Plantain] {
 
   def addTriple(mgraph: Plantain#MGraph, triple: Plantain#Triple): mgraph.type = {
     val (s, p, o) = triple
-    mgraph.graph = mgraph.graph + (s, p, o)
+    mgraph.graph += (s, p, o)
     mgraph
   }
 
   def removeTriple(mgraph: Plantain#MGraph, triple: Plantain#Triple): mgraph.type = {
     val (s, p, o) = triple
-    mgraph.graph = mgraph.graph - (s, p, o)
+    mgraph.graph -= (s, p, o)
     mgraph
   }
 

--- a/plantain/js/src/main/scala/org/w3/banana/plantain/PlantainMGraphOps.scala
+++ b/plantain/js/src/main/scala/org/w3/banana/plantain/PlantainMGraphOps.scala
@@ -10,13 +10,13 @@ trait PlantainMGraphOps extends MGraphOps[Plantain] {
 
   def addTriple(mgraph: Plantain#MGraph, triple: Plantain#Triple): mgraph.type = {
     val (s, p, o) = triple
-    mgraph.graph += (s, p, o)
+    mgraph.graph = mgraph.graph + (s, p, o)
     mgraph
   }
 
   def removeTriple(mgraph: Plantain#MGraph, triple: Plantain#Triple): mgraph.type = {
     val (s, p, o) = triple
-    mgraph.graph -= (s, p, o)
+    mgraph.graph = mgraph.graph - (s, p, o)
     mgraph
   }
 

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainOps.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainOps.scala
@@ -55,11 +55,11 @@ object PlantainOps extends RDFOps[Plantain] with PlantainMGraphOps with Plantain
 
   // literal
 
-  final val rdfLangString = makeUri("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")
-  final val xsdInteger = makeUri("http://www.w3.org/2001/XMLSchema#integer")
-  final val xsdString = makeUri("http://www.w3.org/2001/XMLSchema#string")
-  final val xsdBoolean = makeUri("http://www.w3.org/2001/XMLSchema#boolean")
-  final val xsdDouble = makeUri("http://www.w3.org/2001/XMLSchema#double")
+  final val rdfLangString: Uri = makeUri("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")
+  final val xsdInteger: Uri    = makeUri("http://www.w3.org/2001/XMLSchema#integer")
+  final val xsdString: Uri     = makeUri("http://www.w3.org/2001/XMLSchema#string")
+  final val xsdBoolean: Uri    = makeUri("http://www.w3.org/2001/XMLSchema#boolean")
+  final val xsdDouble: Uri     = makeUri("http://www.w3.org/2001/XMLSchema#double")
 
   final def makeLiteral(lexicalForm: String, datatype: Plantain#URI): Plantain#Literal = datatype match {
     case `xsdInteger`   => new BigInteger(lexicalForm)
@@ -96,7 +96,7 @@ object PlantainOps extends RDFOps[Plantain] with PlantainMGraphOps with Plantain
   final def foldNodeMatch[T](
     nodeMatch: Plantain#NodeMatch)(
     funANY: => T,
-      funConcrete: Plantain#Node => T
+    funConcrete: Plantain#Node => T
   ): T = nodeMatch match {
     case null => funANY
     case node => funConcrete(node)

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainURIOps.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainURIOps.scala
@@ -22,23 +22,20 @@ trait PlantainURIOps extends URIOps[Plantain] {
   def resolve(uri: Plantain#URI, other: Plantain#URI): Plantain#URI =
     other.resolvedAgainst(uri)
 
-  def appendSegment(uri: Plantain#URI, segment: String): Plantain#URI = {
-    val path = uri.path
-    if (path.reverse.startsWithSlash)
-      uri.copy(path = path + segment)
-    else
-      uri.copy(path = path / segment)
-  }
+  def appendSegment(uri: Plantain#URI, segment: String): Plantain#URI =
+    uri.withPath(uri.path ?/ segment)
 
-  // TODO should rely on a spray.http.Uri when https://github.com/spray/spray/issues/818 is addressed
-  // for implementation algorithm, see https://github.com/stain/cxf/blob/trunk/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/HttpUtils.java
+  /** TODO: avoid going through Java
+   * for implementation algorithm, see [[https://github.com/stain/cxf/blob/trunk/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/HttpUtils.java  HttpUtils.java]]
+   */
   def relativize(uri: Plantain#URI, other: Plantain#URI): Plantain#URI = {
     import java.net.{URI => jURI}
     val juri = new jURI(uri.toString).relativize(new jURI(other.toString))
     Uri(juri.toString)
   }
 
-  def lastSegment(uri: Plantain#URI): String =
+  def lastSegment(uri: Plantain#URI): String = {
     uri.path.reverse.head.toString
+  }
 
 }

--- a/plantain/shared/src/main/scala/org/w3/banana/plantain/model/Graph.scala
+++ b/plantain/shared/src/main/scala/org/w3/banana/plantain/model/Graph.scala
@@ -99,15 +99,15 @@ case class Graph[S, P, O](spo: Map[S, Map[P, Vector[O]]], size: Int) {
         for {
           (s, pos) <- subject match {
             case None       => spo
-            case Some(node) => spo.filterKeys { _ == node }
+            case Some(node) => spo.view.filterKeys( _ == node)
           }
           (p, os) <- predicate match {
             case None       => pos
-            case Some(node) => pos filterKeys { _ == node }
+            case Some(node) => pos.view.filterKeys(_ == node)
           }
           o <- objectt match {
             case None => os
-            case Some(node) => if (os contains node) os else Iterable.empty
+            case Some(node) => os.find(_ == node).toSeq
           }
         } yield (s, p, o)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,29 +10,29 @@ object Dependencies {
 
   /**
     * scalaz
-    * @see http://scalaz.org
-    * @see http://repo1.maven.org/maven2/org/scalaz/
+    * @see https://scalaz.org
+    * @see https://repo1.maven.org/maven2/org/scalaz/
     */
    val scalaz = Def.setting("org.scalaz" %%% "scalaz-core" % "7.4.0-M7")
 
   /**
    * joda-Time
-   * @see http://joda-time.sourceforge.net
+   * @see https://joda-time.sourceforge.net
    * @see https://repo1.maven.org/maven2/joda-time/joda-time/
    */
   val jodaTime = "joda-time" % "joda-time" % "2.9.6"
 
   /**
    * joda-convert
-   * @see http://joda-convert.sourceforge.net
-   * @see http://repo1.maven.org/maven2/org/joda/joda-convert
+   * @see https://joda-convert.sourceforge.net
+   * @see https://repo1.maven.org/maven2/org/joda/joda-convert
    */
   val jodaConvert = "org.joda" % "joda-convert" % "1.8.1"
 
   /**
    * scalatest
-   * @see http://www.scalatest.org
-   * @see http://repo1.maven.org/maven2/org/scalatest
+   * @see https://www.scalatest.org
+   * @see https://repo1.maven.org/maven2/org/scalatest
    */
   val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.7")
 
@@ -41,32 +41,32 @@ object Dependencies {
    * @see https://akka.io
    * @see https://repo1.maven.org/maven2/com/typesafe/akka
    */
-  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % "10.2.4"
-  val akka = "com.typesafe.akka" %% "akka-actor-typed" % "2.6.13"
+  val akkaHttpCore = ("com.typesafe.akka" %% "akka-http-core" % "10.2.4") cross CrossVersion.for3Use2_13
+  val akka = ("com.typesafe.akka" %% "akka-actor-typed" % "2.6.13") cross CrossVersion.for3Use2_13
 
   /**
    * jena
    * @see https://jena.apache.org/
-   * @see http://repo1.maven.org/maven2/org/apache/jena
+   * @see https://repo1.maven.org/maven2/org/apache/jena
    */
   val jenaLibs = "org.apache.jena" % "apache-jena-libs" % "3.17.0"
 
   /**
    * slf4j-nop. Test dependency for logging.
-   * @see http://www.slf4j.org
+   * @see https://www.slf4j.org
    */
   val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.7.21" % Test
 
   /**
    * Aalto
-   * @see http://wiki.fasterxml.com/AaltoHome
-   * @see http://repo1.maven.org/maven2/com/fasterxml/aalto-xml
+   * @see https://wiki.fasterxml.com/AaltoHome
+   * @see https://repo1.maven.org/maven2/com/fasterxml/aalto-xml
    */
   val aalto = "com.fasterxml" % "aalto-xml" % "1.0.0"
 
   /**
    * RDF4J
-   * @see http://www.rdf4j.org/
+   * @see https://www.rdf4j.org/
    * @see https://repo1.maven.org/maven2/org/eclipse/rdf4j/
    */
   val rdf4jVersion = "3.6.1"
@@ -89,21 +89,15 @@ object Dependencies {
   val jsonldJava = "com.github.jsonld-java" % "jsonld-java" % "0.13.2"
 
   /**
-   * Java 8 Compatibility kit (needed until move to scala 2.13 is complete
-   * https://index.scala-lang.org/scala/scala-java8-compat/scala-java8-compat/0.8.0
-   */
-  //val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
-
-  /**
    * parboiled
-   * @see http://parboiled.org
+   * @see https://parboiled.org
    * @see https://repo1.maven.org/maven2/org/parboiled/
    */
   val parboiled2 = "org.parboiled" %% "parboiled" % "2.1.3"
 
   /**
    * jena-fuseki
-   * @see http://jena.apache.org/documentation/serving_data
+   * @see https://jena.apache.org/documentation/serving_data
    * @see https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki/
    */
   val fuseki = "org.apache.jena" % "jena-fuseki-main" % "3.17.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,5 @@
-import sbt._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
-import sbt.Keys.scalaVersion
-import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject, _}
-import scalajscrossproject.ScalaJSCrossPlugin.autoImport._
+import sbt._
 
 
 object Dependencies {
@@ -34,7 +31,7 @@ object Dependencies {
    * @see https://www.scalatest.org
    * @see https://repo1.maven.org/maven2/org/scalatest
    */
-  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.7")
+  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.8")
 
   /**
    * Akka Http Core
@@ -42,7 +39,7 @@ object Dependencies {
    * @see https://repo1.maven.org/maven2/com/typesafe/akka
    */
   val akkaHttpCore = ("com.typesafe.akka" %% "akka-http-core" % "10.2.4") cross CrossVersion.for3Use2_13
-  val akka = ("com.typesafe.akka" %% "akka-actor-typed" % "2.6.13") cross CrossVersion.for3Use2_13
+  val akka = ("com.typesafe.akka" %% "akka-actor-typed" % "2.6.14") cross CrossVersion.for3Use2_13
 
   /**
    * jena
@@ -69,7 +66,7 @@ object Dependencies {
    * @see https://www.rdf4j.org/
    * @see https://repo1.maven.org/maven2/org/eclipse/rdf4j/
    */
-  val rdf4jVersion = "3.6.1"
+  val rdf4jVersion = "3.6.3"
 
   val rdf4jQueryAlgebra = "org.eclipse.rdf4j" % "rdf4j-queryalgebra-evaluation" % rdf4jVersion
   val rdf4jQueryParser = "org.eclipse.rdf4j" % "rdf4j-queryparser-sparql" % rdf4jVersion
@@ -103,5 +100,5 @@ object Dependencies {
   val fuseki = "org.apache.jena" % "jena-fuseki-main" % "3.17.0"
   
   val servlet = "javax.servlet" % "javax.servlet-api" % "3.1.0"
-  val httpComponents = "org.apache.httpcomponents" % "httpclient" % "4.5.3"
+  val httpComponents = "org.apache.httpcomponents" % "httpclient" % "4.5.13"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,6 +1,7 @@
 import sbt._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
-import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType, _}
+import sbt.Keys.scalaVersion
+import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject, _}
 import scalajscrossproject.ScalaJSCrossPlugin.autoImport._
 
 
@@ -12,7 +13,7 @@ object Dependencies {
     * @see http://scalaz.org
     * @see http://repo1.maven.org/maven2/org/scalaz/
     */
-  val scalaz = Def.setting("org.scalaz" %%% "scalaz-core" % "7.3.1")
+   val scalaz = Def.setting("org.scalaz" %%% "scalaz-core" % "7.4.0-M7")
 
   /**
    * joda-Time
@@ -33,8 +34,8 @@ object Dependencies {
    * @see http://www.scalatest.org
    * @see http://repo1.maven.org/maven2/org/scalatest
    */
-  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.1.2")
-  
+  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.6")
+
   /**
    * Akka Http Core
    * @see https://akka.io
@@ -91,7 +92,7 @@ object Dependencies {
    * Java 8 Compatibility kit (needed until move to scala 2.13 is complete
    * https://index.scala-lang.org/scala/scala-java8-compat/scala-java8-compat/0.8.0
    */
-  val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
+  //val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
 
   /**
    * parboiled

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,15 +34,15 @@ object Dependencies {
    * @see http://www.scalatest.org
    * @see http://repo1.maven.org/maven2/org/scalatest
    */
-  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.6")
+  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.7")
 
   /**
    * Akka Http Core
    * @see https://akka.io
    * @see https://repo1.maven.org/maven2/com/typesafe/akka
    */
-  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % "10.1.12"
-  val akka = "com.typesafe.akka" %% "akka-actor-typed" % "2.6.6"
+  val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % "10.2.4"
+  val akka = "com.typesafe.akka" %% "akka-actor-typed" % "2.6.13"
 
   /**
    * jena

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0-RC2
+sbt.version=1.5.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.3
+sbt.version=1.5.0-RC2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,9 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
+/** Dotty plugin */
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
+
 //addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
 /**
@@ -21,7 +24,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
   *
   * @see https://github.com/portable-scala/sbt-crossproject
   */
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.0.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
 /**
   * jsdependencies t sbt plugin
@@ -61,7 +64,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
   * better ivy alternative for dependency resolution
   * @see https://github.com/alexarchambault/coursier
   */
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
+// addSbtPlugin("io.get-coursier" % "sbt-coursier" % "2.0.0-RC6-8")
 
 /**
   * sbt-updates
@@ -69,17 +72,17 @@ addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
   * for easier dependency updates monitoring
   * @see https://github.com/rtimush/sbt-updates
   */
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.2")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.2")
 
 /**
  * sbtsonatype plugin used to publish artifact to maven central via sonatype nexus
  * @see https://github.com/xerial/sbt-sonatype
  */
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 
 
   /**
   * plugin used to sign the artifcat with pgp keys
   * @see https://github.com/sbt/sbt-pgp
   */
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,12 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
-/** Dotty plugin */
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
-addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.4.0-SNAPSHOT")
-//addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
+/** Dotty plugin no longer needed for sbt 1.5.0  */
+//addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.4")
+/** scala3 migrate, kept here for references. Remove when migration complete */
+//addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.4.0-SNAPSHOT")
 
+//addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
 /**
   * Bintray pluging

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,9 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
 /** Dotty plugin */
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
-
+addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.3.1")
 //addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
+
 
 /**
   * Bintray pluging

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
 /** Dotty plugin */
 addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
-addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.3.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scala3-migrate" % "0.4.0-SNAPSHOT")
 //addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
 

--- a/rdf-test-suite/js/src/main/scala/org/w3/banana/binder/CustomBindersTest.scala
+++ b/rdf-test-suite/js/src/main/scala/org/w3/banana/binder/CustomBindersTest.scala
@@ -16,7 +16,7 @@ class CustomBindersTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWordSp
 
     val date = new js.Date(1989, 11, 9)
     //Javascript has no compare operator for dates so one must compare strings/ms etc
-    date.toPG.as[js.Date].get.toDateString shouldEqual date.toDateString
+    date.toPG.as[js.Date].get.toDateString() shouldEqual date.toDateString()
     date.toPG.as[js.Date].get.getMilliseconds() shouldEqual date.getMilliseconds()
   }
 

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/FusekiServer.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/FusekiServer.scala
@@ -6,6 +6,7 @@ import org.apache.jena.fuseki.jetty.JettyServerConfig
 import org.apache.jena.query.Dataset
 import org.apache.jena.util.FileManager
 import org.apache.jena.fuseki.main.{FusekiServer => JenaFusekiServer}
+import org.apache.jena.riot.RDFDataMgr
 
 
 /**

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/SparqlEngineTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/SparqlEngineTest.scala
@@ -41,7 +41,7 @@ class SparqlEngineTest[Rdf <: RDF, A](
                            |}""".stripMargin).success.value
 
     val names: Iterable[String] =
-      store.executeSelect(query).get.iterator.to(Iterable).map {
+      store.executeSelect(query).get.iterator().to(Iterable).map {
         row => row("name").success.value.as[String].success.value
       }
 
@@ -68,7 +68,7 @@ class SparqlEngineTest[Rdf <: RDF, A](
       "prop" -> URI("http://www.w3.org/2000/10/swap/pim/contact#fullName"))
 
     val names: Iterable[String] =
-      store.executeSelect(query, bindings).get.iterator.to(Iterable).map {
+      store.executeSelect(query, bindings).get.iterator().to(Iterable).map {
         row => row("name").success.value.as[String].success.value
       }
 

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/SparqlGraphTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/SparqlGraphTest.scala
@@ -40,7 +40,7 @@ class SparqlGraphTest[Rdf <: RDF, SyntaxType](implicit
                          """.stripMargin
 
     def testAnswer(solutions: Rdf#Solutions) = {
-      val rows = solutions.iterator.to(List)
+      val rows = solutions.iterator().to(List)
 
       val names: List[String] = rows.map {
         row => row("name").success.value.as[String].success.value
@@ -72,7 +72,7 @@ class SparqlGraphTest[Rdf <: RDF, SyntaxType](implicit
       val answr2 = sparqlReader.read(new ByteArrayInputStream(out.toByteArray), "")
       assert(answr2.isSuccess, "the serialised sparql answers must be deserialisable")
 
-      answr2.map(a => assert(testAnswer(a.left.get), "the deserialised answer must pass the same tests as the original one"))
+      answr2.map(a => assert(testAnswer(a.swap.getOrElse(fail("no solutions"))), "the deserialised answer must pass the same tests as the original one"))
     }
   }
 

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/SparqlUpdateEngineTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/SparqlUpdateEngineTest.scala
@@ -64,7 +64,7 @@ class SparqlUpdateEngineTest[Rdf <: RDF, A](
           |}
         """.stripMargin).success.value
 
-    val projects = store.executeSelect(selectQuery).get.iterator.to(Iterable)
+    val projects = store.executeSelect(selectQuery).get.iterator().to(Iterable)
     val result = projects.map(row =>
       row("currentProject").success.value.as[Rdf#URI].success.value
     )

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/io/NTriplesReaderTestSuite.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/io/NTriplesReaderTestSuite.scala
@@ -69,7 +69,7 @@ class NTriplesReaderTestSuite[Rdf <: RDF](implicit
     "not parse a plain Literal that does not close" in {
       val nt = ntparser(name)
       val lit = Try(nt.parseLiteral())
-      lit should be a 'failure
+      lit should be a Symbol("failure")
     }
 
     "parse a PlainLiteral"  in {
@@ -99,7 +99,7 @@ class NTriplesReaderTestSuite[Rdf <: RDF](implicit
     
     "not parse an illegal BNode" in {
       val bn = Try (ntparser(":-123 ").parseBNode())
-      bn should be a 'failure
+      bn should be a Symbol("failure")
     }
 
   }
@@ -411,7 +411,7 @@ class NTriplesReaderTestSuite[Rdf <: RDF](implicit
     }
 
     "literal all controls" in {
-      val lit="""<http://a.example/s> <http://a.example/p> "\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\u0008\t""" +
+      val lit= """<http://a.example/s> <http://a.example/p> "\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\u0008\t""" +
         """\\u000B\\u000C\\u000E\\u000F\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001A\\u001B\\u001C""" +
         """\\u001D\\u001E\\u001F" ."""
       test(lit,1)
@@ -640,7 +640,7 @@ class NTriplesReaderTestSuite[Rdf <: RDF](implicit
     var x = 0
     var failures = 0
     while (ntp.hasNext) {
-      val t = ntp.next
+      val t = ntp.next()
       x = x + 1
       if (t.isFailure) {
         println(s"\r\ntriple=$t")

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/isomorphism/GraphIsomorphismTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/isomorphism/GraphIsomorphismTest.scala
@@ -3,11 +3,10 @@ package org.w3.banana.isomorphism
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.Suite
-
-import org.w3.banana.{ RDF, RDFOps }
+import org.w3.banana.{PointedGraph, RDF, RDFOps}
 
 import scala.collection.immutable.ListMap
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 /**
  * Tests for the pure Scala implementation of Graph Isomorphism
@@ -92,7 +91,7 @@ class GraphIsomorphismTest[Rdf <: RDF](isoFactory: (() => VerticeCBuilder[Rdf]) 
 
     "two graphs with 2 relations and 2 bnodes each" in {
       for (
-        l <- findPossibleMappings(
+        l <- possibleMappings(
           bnAlexRel1Graph(1) union bnAntonioRel1Graph(1),
           bnAlexRel1Graph(2) union bnAntonioRel1Graph(2))
       ) {
@@ -116,7 +115,7 @@ class GraphIsomorphismTest[Rdf <: RDF](isoFactory: (() => VerticeCBuilder[Rdf]) 
       | The category with 1 solutions must be shown first""".stripMargin in {
       val g1 = bnAlexRel1Graph(1) union bnAntonioRel1Graph(1) union bnAlexRel2Graph(2) union bnAlexRel1Graph(0) union bnAlexRel2Graph(0)
       val g2 = bnAlexRel1Graph(3) union bnAntonioRel1Graph(3) union bnAntonioRel2Graph(4) union bnAlexRel1Graph(5) union bnAlexRel2Graph(5)
-      val answers = findPossibleMappings(g1, g2)
+      val answers = possibleMappings(g1, g2)
       val answer = findAnswer(g1, g2)
       answer.isFailure should be(true)
 
@@ -246,7 +245,7 @@ class GraphIsomorphismTest[Rdf <: RDF](isoFactory: (() => VerticeCBuilder[Rdf]) 
     "a 1 triple ground graph" in {
       val g1 = (hjs -- foaf.name ->- "Henry Story").graph
       val expected = Graph(Triple(hjs, foaf.name, Literal("Henry Story")))
-      findAnswer(g1, expected).isSuccess should be(true)
+      findAnswer(g1, expected) should be(Success(List()))
 
       val nonExpected = Graph(Triple(hjs, foaf.name, Literal("Henri Story")))
       findAnswer(g1, nonExpected).isSuccess should be(false)
@@ -255,7 +254,7 @@ class GraphIsomorphismTest[Rdf <: RDF](isoFactory: (() => VerticeCBuilder[Rdf]) 
     "two grounded graphs with 2 relations" in {
       val g1 = groundedGraph
       val expected = groundedGraph
-      findAnswer(g1, expected).isSuccess should be(true)
+      findAnswer(g1, expected) should be(Success(List()))
     }
 
     "list of size 1" in {

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/GraphUnionTest.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/GraphUnionTest.scala
@@ -43,7 +43,7 @@ abstract class GraphUnionTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends Any
     val result = union(foo :: bar :: Nil)
     isomorphism(foo, fooReference) shouldEqual true
     isomorphism(bar, barReference) shouldEqual true
-    ! isomorphism(foo, bar) shouldEqual true
+    isomorphism(foo, bar) shouldEqual false
     isomorphism(foobar, result) shouldEqual true
   }
 

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/CommonBindersTest.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/CommonBindersTest.scala
@@ -102,7 +102,7 @@ class CommonBindersTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWordSp
     (None: Option[String]).toPG.as[Option[String]] shouldEqual Success(None)
   }
 
-  def `this must compile` {
+  def `this must compile` : Unit = {
     implicitly[PGBinder[Rdf, Rdf#URI]]
     implicitly[NodeBinder[Rdf, Rdf#URI]]
     implicitly[PGBinder[Rdf, Rdf#Node]]

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/ObjectExamples.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/ObjectExamples.scala
@@ -4,7 +4,6 @@ import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.interfaces.RSAPublicKey
 import java.security.spec.RSAPublicKeySpec
-
 import org.w3.banana._
 
 import scala.util._

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/RecordBinderTest.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/RecordBinderTest.scala
@@ -26,14 +26,17 @@ class RecordBinderTest[Rdf <: RDF](implicit
 
   "serializing and deserializing a City" in {
     city.toPG.as[City] shouldEqual Success(city)
-
-    val expectedGraph = (
-      URI("http://example.com/Paris").a(City.clazz)
+    val paris = URI("http://ontology.example/Paris")
+    val parisPG: PointedGraph[Rdf] = (
+      paris.a(City.clazz)
       -- foaf("cityName") ->- "Paris"
       -- foaf("otherNames") ->- "Panam"
       -- foaf("otherNames") ->- "Lutetia"
-    ).graph
-    city.toPG.graph.isIsomorphicWith(expectedGraph) shouldEqual true
+    )
+    println("parisPG ="+parisPG.graph)
+    println("city.toPG = "+city.toPG.graph)
+    city.toPG.graph.isIsomorphicWith(parisPG.graph) shouldEqual true
+    parisPG.as[City] shouldEqual Success(city)
   }
 
   "graph constant pointer" in {

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/RecordBinderTest.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/binder/RecordBinderTest.scala
@@ -26,17 +26,19 @@ class RecordBinderTest[Rdf <: RDF](implicit
 
   "serializing and deserializing a City" in {
     city.toPG.as[City] shouldEqual Success(city)
-    val paris = URI("http://ontology.example/Paris")
-    val parisPG: PointedGraph[Rdf] = (
-      paris.a(City.clazz)
-      -- foaf("cityName") ->- "Paris"
-      -- foaf("otherNames") ->- "Panam"
-      -- foaf("otherNames") ->- "Lutetia"
-    )
-    println("parisPG ="+parisPG.graph)
-    println("city.toPG = "+city.toPG.graph)
-    city.toPG.graph.isIsomorphicWith(parisPG.graph) shouldEqual true
-    parisPG.as[City] shouldEqual Success(city)
+// todo: we need a way to map a URI for an object to a field of the object
+//    val paris = URI("http://ontology.example/Paris")
+//    val parisPG: PointedGraph[Rdf] = (
+//      paris.a(City.clazz)
+//      -- foaf("cityName") ->- "Paris"
+//      -- foaf("otherNames") ->- "Panam"
+//      -- foaf("otherNames") ->- "Lutetia"
+//    )
+//    // todo: we need a way to be able to add the
+    //println("parisPG ="+parisPG.graph)
+    //println("city.toPG = "+city.toPG.graph)
+//    city.toPG.graph.isIsomorphicWith(parisPG.graph) shouldEqual true
+//    parisPG.as[City] shouldEqual Success(city)
   }
 
   "graph constant pointer" in {

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/diesel/DieselGraphConstructTest.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/diesel/DieselGraphConstructTest.scala
@@ -70,7 +70,7 @@ class DieselGraphConstructTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends An
         Triple(URI("http://bblfish.net/#hjs"), foaf.name, Literal("Henry Story"))
       )
 
-    (g.graph isIsomorphicWith expectedGraph)  shouldEqual true
+    (g.graph isIsomorphicWith expectedGraph) shouldEqual true
   }
 
   "Diesel must allow easy use of rdf:type through the method 'a'" in {

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/diesel/DieselOwlPrimerTest.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/diesel/DieselOwlPrimerTest.scala
@@ -108,7 +108,7 @@ class DieselOwlPrimerTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWord
     def equivalentClasses(ce:Rdf#URI,pg:PointedGraph[Rdf]):PointedGraph[Rdf] = ce -- owl.equivalentClass ->- pg
 
     def objectComplementOf(ce:Rdf#URI):PointedGraph[Rdf] = (
-      bnode -- rdf.typ          ->- owl.Class
+      bnode() -- rdf.typ          ->- owl.Class
             -- owl.complementOf ->- ce
       )
     def ¬(ce:Rdf#URI):PointedGraph[Rdf] = objectComplementOf(ce)
@@ -168,10 +168,10 @@ class DieselOwlPrimerTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWord
     import Owl2._
 
     val g:Rdf#Graph = Seq (
-        f.ChildlessPerson -- owl.equivalentClass ->- ( bnode
+        f.ChildlessPerson -- owl.equivalentClass ->- ( bnode()
         -- rdf.typ            ->- owl.Class
         -- owl.intersectionOf ->- List( f.Person.toPG,
-                                        bnode -- rdf.typ          ->- owl.Class
+                                        bnode() -- rdf.typ          ->- owl.Class
                                               -- owl.complementOf ->- f.Parent))
     )
 
@@ -238,7 +238,7 @@ class DieselOwlPrimerTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWord
 
 
       f.Mother --   rdfs.subClassOf ->- f.Woman
-               --  owl.equivalentClass ->- (bnode
+               --  owl.equivalentClass ->- (bnode()
         -- rdf.typ            ->-  owl.Class
         -- owl.intersectionOf ->- ( f.Woman,  f.Parent )),
 
@@ -249,58 +249,58 @@ class DieselOwlPrimerTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWord
         -- owl.equivalentClass ->- f.Human
         -- owl.hasKey          ->- f.hasSSN,
 
-      f.Parent -- owl.equivalentClass ->- (bnode
+      f.Parent -- owl.equivalentClass ->- (bnode()
         -- rdf.typ     ->- owl.Class
         -- owl.unionOf ->-(f.Mother, f.Father)),
 
-      f.Parent -- owl.equivalentClass ->- (bnode
+      f.Parent -- owl.equivalentClass ->- (bnode()
         -- rdf.typ            ->- owl.Restriction
         -- owl.onProperty     ->- f.hasChild
         -- owl.someValuesFrom ->- f.Person ),
 
-      f.Grandfather -- rdfs.subClassOf  ->- (bnode
+      f.Grandfather -- rdfs.subClassOf  ->- (bnode()
         -- rdf.typ            ->- owl.Class
         -- owl.intersectionOf ->- ( f.Man,  f.Parent )),
 
-      f.HappyPerson -- owl.equivalentClass  ->- (bnode
+      f.HappyPerson -- owl.equivalentClass  ->- (bnode()
         -- rdf.typ ->-      owl.Class
-        -- owl.intersectionOf ->- ( bnode -- rdf.typ            ->- owl.Restriction
+        -- owl.intersectionOf ->- ( bnode() -- rdf.typ            ->- owl.Restriction
                                           -- owl.onProperty     ->- f.hasChild
                                           -- owl.allValuesFrom  ->- f.HappyPerson,
-                                    bnode -- rdf.typ            ->- owl.Restriction
+                                    bnode() -- rdf.typ            ->- owl.Restriction
                                           -- owl.onProperty     ->- f.hasChild
                                           -- owl.someValuesFrom ->- f.HappyPerson)),
 
-      f.JohnsChildren -- owl.equivalentClass ->- ( bnode
+      f.JohnsChildren -- owl.equivalentClass ->- ( bnode()
         -- rdf.typ        ->- owl.Restriction
         -- owl.onProperty ->- f.hasParent
         -- owl.hasValue   ->- f.John),
 
-      f.NarcisticPerson -- owl.equivalentClass ->- ( bnode
+      f.NarcisticPerson -- owl.equivalentClass ->- ( bnode()
         -- rdf.typ   ->-     owl.Restriction
         -- owl.onProperty ->- f.loves
         -- owl.hasSelf   ->-  true ),
 
-      f.MyBirthdayGuests -- owl.equivalentClass ->- ( bnode
+      f.MyBirthdayGuests -- owl.equivalentClass ->- ( bnode()
         -- rdf.typ ->-  owl.Class
         -- owl.oneOf ->- ( f.Bill, f.John, f.Mary )),
 
-      f.Orphan --  owl.equivalentClass ->- ( bnode
+      f.Orphan --  owl.equivalentClass ->- ( bnode()
         -- rdf.typ ->-           owl.Restriction
-        -- owl.onProperty    ->- (bnode -- owl.inverseOf ->-  f.hasChild)
+        -- owl.onProperty    ->- (bnode() -- owl.inverseOf ->-  f.hasChild)
         -- owl.allValuesFrom ->- f.Dead),
 
-      f.Teenager -- rdfs.subClassOf ->- ( bnode
+      f.Teenager -- rdfs.subClassOf ->- ( bnode()
         -- rdf.typ            ->- owl.Restriction
         -- owl.onProperty     ->- f.hasAge
-        -- owl.someValuesFrom ->- ( bnode
+        -- owl.someValuesFrom ->- ( bnode()
           -- rdf.typ              ->- rdfs.Datatype
           -- owl.onDatatype       ->- xsd.integer
-          -- owl.withRestrictions ->- ( bnode -- xsd.minExclusive ->- 12,
-                                        bnode -- xsd.maxInclusive ->- 19))),
+          -- owl.withRestrictions ->- ( bnode() -- xsd.minExclusive ->- 12,
+                                        bnode() -- xsd.maxInclusive ->- 19))),
 
       f.Man -- rdfs.subClassOf       ->- f.Person,
-      bnode -- rdf.typ               ->- owl.Axiom
+      bnode() -- rdf.typ               ->- owl.Axiom
             -- owl.annotatedSource   ->- f.Man
             -- owl.annotatedProperty ->- rdfs.subClassOf
             -- owl.annotatedTarget   ->- f.Person
@@ -308,56 +308,56 @@ class DieselOwlPrimerTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWord
 
       f.Adult -- owl.equivalentClass ->-otherOnt("Grownup"),
 
-      f.Father -- rdfs.subClassOf  ->- ( bnode
+      f.Father -- rdfs.subClassOf  ->- ( bnode()
         -- rdf.typ            ->- owl.Class
         -- owl.intersectionOf ->- ( f.Man,  f.Parent )),
 
-      f.ChildlessPerson -- owl.equivalentClass ->- ( bnode
+      f.ChildlessPerson -- owl.equivalentClass ->- ( bnode()
         -- rdf.typ            ->- owl.Class
-        -- owl.intersectionOf ->- ( f.Person.toPG, bnode -- owl.complementOf ->- f.Parent)),
+        -- owl.intersectionOf ->- ( f.Person.toPG, bnode() -- owl.complementOf ->- f.Parent)),
 
-      f.ChildlessPerson -- rdfs.subClassOf ->- ( bnode
+      f.ChildlessPerson -- rdfs.subClassOf ->- ( bnode()
         -- rdf.typ            ->- owl.Class
         -- owl.intersectionOf ->- ( f.Person.toPG,
-                                    bnode -- owl.complementOf ->- ( bnode
+                                    bnode() -- owl.complementOf ->- ( bnode()
                                       -- rdf.typ            ->- owl.Restriction
-                                      -- owl.onProperty     ->- (bnode -- owl.inverseOf ->- f.hasParent)
+                                      -- owl.onProperty     ->- (bnode() -- owl.inverseOf ->- f.hasParent)
                                       -- owl.someValuesFrom ->- owl.Thing))),
 
-      bnode -- rdf.typ            ->- owl.Class
-            -- owl.intersectionOf ->- ( bnode -- rdf.typ   ->- owl.Class
+      bnode() -- rdf.typ            ->- owl.Class
+            -- owl.intersectionOf ->- ( bnode() -- rdf.typ   ->- owl.Class
                                               -- owl.oneOf ->- ( f.Mary,  f.Bill,  f.Meg ),
                                       f.Female.toPG)
-            -- rdfs.subClassOf ->- ( bnode
+            -- rdfs.subClassOf ->- ( bnode()
               -- rdf.typ            ->- owl.Class
               -- owl.intersectionOf ->- ( f.Parent.toPG,
-                                          bnode -- rdf.typ            ->- owl.Restriction
+                                          bnode() -- rdf.typ            ->- owl.Restriction
                                                 -- owl.maxCardinality ->- 1 //^^xsdf.nonNegativeInteger ;
                                                 -- owl.onProperty     ->- f.hasChild,
-                                          bnode -- rdf.typ            ->- owl.Restriction
+                                          bnode() -- rdf.typ            ->- owl.Restriction
                                                 -- owl.onProperty     ->- f.hasChild
                                                 -- owl.allValuesFrom  ->- f.Female)),
 
-      bnode -- rdf.typ     ->- owl.AllDisjointClasses
+      bnode() -- rdf.typ     ->- owl.AllDisjointClasses
             -- owl.members ->- ( f.Mother,  f.Father,  f.YoungChild ),
 
-      bnode -- rdf.typ     ->- owl.AllDisjointClasses
+      bnode() -- rdf.typ     ->- owl.AllDisjointClasses
             -- owl.members ->- ( f.Woman,  f.Man ),
 
-      f.personAge --  owl.equivalentClass ->- ( bnode
+      f.personAge --  owl.equivalentClass ->- ( bnode()
         -- rdf.typ              ->- rdfs.Datatype
         -- owl.onDatatype       ->- xsd.integer
-        -- owl.withRestrictions ->- ( bnode -- xsd.minInclusive ->- 0,
-                                      bnode -- xsd.maxInclusive ->- 150)),
+        -- owl.withRestrictions ->- ( bnode() -- xsd.minInclusive ->- 0,
+                                      bnode() -- xsd.maxInclusive ->- 150)),
 
-      f.majorAge -- owl.equivalentClass ->- ( bnode
+      f.majorAge -- owl.equivalentClass ->- ( bnode()
         -- rdf.typ ->-  rdfs.Datatype
         -- owl.intersectionOf ->- (
              f.personAge.toPG,
-             bnode -- rdf.typ                  ->- rdfs.Datatype
+             bnode() -- rdf.typ                  ->- rdfs.Datatype
                    -- owl.datatypeComplementOf ->- f.minorAge)),
 
-      f.toddlerAge --  owl.equivalentClass ->- ( bnode
+      f.toddlerAge --  owl.equivalentClass ->- ( bnode()
         -- rdf.typ   ->- rdfs.Datatype
         -- owl.oneOf ->- ( 1, 2)),
 
@@ -367,10 +367,10 @@ class DieselOwlPrimerTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWord
 
       f.James -- owl.sameAs ->- f.Jim,
 
-      f.Jack -- rdf.typ ->- ( bnode
+      f.Jack -- rdf.typ ->- ( bnode()
         -- rdf.typ            ->- owl.Class
         -- owl.intersectionOf ->- ( f.Person.toPG,
-                                    bnode -- rdf.typ ->-          owl.Class
+                                    bnode() -- rdf.typ ->-          owl.Class
                                           -- owl.complementOf ->- f.Parent )),
 
 
@@ -381,42 +381,42 @@ class DieselOwlPrimerTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWord
       f.John -- owl.differentFrom ->- f.Bill,
       f.John -- f.hasAge          ->- 51,
 
-      f.John -- rdf.typ ->- ( bnode
+      f.John -- rdf.typ ->- ( bnode()
         -- rdf.typ                     ->- owl.Restriction
         -- owl.maxQualifiedCardinality ->- 4
         -- owl.onProperty              ->-  f.hasChild
         -- owl.onClass                 ->-  f.Parent),
 
-      f.John --  rdf.typ ->- ( bnode
+      f.John --  rdf.typ ->- ( bnode()
         -- rdf.typ                      ->- owl.Restriction
         -- owl.minQualifiedCardinality  ->- 2
         -- owl.onProperty               ->- f.hasChild
         -- owl.onClass                  ->- f.Parent),
 
-      f.John -- rdf.typ ->- ( bnode
+      f.John -- rdf.typ ->- ( bnode()
         -- rdf.typ                   ->- owl.Restriction
         -- owl.qualifiedCardinality  ->- 3
         -- owl.onProperty            ->- f.hasChild
         -- owl.onClass               ->- f.Parent),
 
-    f.John -- rdf.typ ->- ( bnode
+    f.John -- rdf.typ ->- ( bnode()
       --rdf.typ         ->- owl.Restriction
       --owl.cardinality ->- 5
       --owl.onProperty  ->- f.hasChild),
 
     f.Father -- rdf.typ ->- f.SocialRole,
 
-    bnode -- rdf.typ                ->- owl.NegativePropertyAssertion
+    bnode() -- rdf.typ                ->- owl.NegativePropertyAssertion
           -- owl.sourceIndividual   ->- f.Bill
           -- owl.assertionProperty  ->- f.hasWife
           -- owl.targetIndividual   ->- f.Mary,
 
-    bnode -- rdf.typ               ->- owl.NegativePropertyAssertion
+    bnode() -- rdf.typ               ->- owl.NegativePropertyAssertion
           -- owl.sourceIndividual  ->- f.Bill
           -- owl.assertionProperty ->- f.hasDaughter
           -- owl.targetIndividual  ->- f.Susan,
 
-    bnode --  rdf.typ               ->- owl.NegativePropertyAssertion
+    bnode() --  rdf.typ               ->- owl.NegativePropertyAssertion
           -- owl.sourceIndividual   ->- f.Jack
           -- owl.assertionProperty  ->- f.hasAge
           -- owl.targetValue        ->- 53
@@ -460,7 +460,7 @@ class DieselOwlPrimerTest[Rdf <: RDF](implicit ops: RDFOps[Rdf]) extends AnyWord
         -- owl.equivalentClass ->- f.Human
         -- owl.hasKey ->- f.hasSSN,
 
-      f.Parent -- owl.equivalentClass ->- (bnode
+      f.Parent -- owl.equivalentClass ->- (bnode()
         -- rdf.typ ->- owl.Class
         -- owl.unionOf ->-(f.John, f.Bill)
         )

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/isomorphism/IsomorphismBNodeTrait.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/isomorphism/IsomorphismBNodeTrait.scala
@@ -23,15 +23,17 @@ trait IsomorphismBNodeTrait[Rdf <: RDF] {
       -- foaf.name ->- "Henry Story"
   ).graph
 
-  def list(size: Int, bnprefix: String) = {
-    def bn(i: Int) = BNode(bnprefix + i)
+  def bn(bnprefix: String)(i: Int) = BNode(bnprefix + i)
+
+  def list(size: Int, bnPrefix: String) = {
+    val p = bnPrefix
     (1 to size).foldRight(
-      Graph(Triple(bn(0), rdf.first, Literal("0", xsd.integer)),
-        Triple(bn(0), rdf.rest, rdf.nil))) {
+      Graph(Triple(bn(p)(0), rdf.first, Literal("0", xsd.integer)),
+        Triple(bn(p)(0), rdf.rest, rdf.nil))) {
         case (i, g) =>
           g union (
-            bn(i) -- rdf.first ->- i
-            -- rdf.rest ->- bn(i - 1)
+            bn(p)(i) -- rdf.first ->- i
+              -- rdf.rest ->- bn(p)(i - 1)
           ).graph
 
       }

--- a/rdf/js/src/main/scala/org/w3/banana/binder/JsDateBinders.scala
+++ b/rdf/js/src/main/scala/org/w3/banana/binder/JsDateBinders.scala
@@ -6,7 +6,7 @@ import scala.util._
 
 object JsDateBinders {
 
-  implicit def JSDateToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) =
+  implicit def JSDateToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToLiteral[Rdf,js.Date] =
     new ToLiteral[Rdf, js.Date] {
       import ops._
       def toLiteral(dateTime: js.Date): Rdf#Literal = {
@@ -15,7 +15,7 @@ object JsDateBinders {
       }
     }
 
-  implicit def JSDateFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromLiteral[Rdf, js.Date] {
+  implicit def JSDateFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromLiteral[Rdf,js.Date] = new FromLiteral[Rdf, js.Date] {
     import ops._
     def fromLiteral(literal: Rdf#Literal): Try[js.Date] = {
       val Literal(lexicalForm, datatype, _) = literal

--- a/rdf/jvm/src/main/scala/org/w3/banana/binder/JodaTimeBinders.scala
+++ b/rdf/jvm/src/main/scala/org/w3/banana/binder/JodaTimeBinders.scala
@@ -6,13 +6,13 @@ import scala.util._
 
 object JodaTimeBinders {
 
-  implicit def DateTimeToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) =
+  implicit def DateTimeToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToLiteral[Rdf,DateTime] =
     new ToLiteral[Rdf, DateTime] {
       import ops._
       def toLiteral(dateTime: DateTime): Rdf#Literal = Literal(dateTime.toString, xsd.dateTime)
     }
 
-  implicit def DateTimeFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromLiteral[Rdf, DateTime] {
+  implicit def DateTimeFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromLiteral[Rdf,DateTime] = new FromLiteral[Rdf, DateTime] {
     import ops._
     def fromLiteral(literal: Rdf#Literal): Try[DateTime] = {
       val Literal(lexicalForm, datatype, _) = literal

--- a/rdf/shared/src/main/scala/org/w3/banana/MGraphOps.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/MGraphOps.scala
@@ -17,13 +17,13 @@ trait MGraphOps[Rdf <: RDF] {
 
   def makeIGraph(mgraph: Rdf#MGraph): Rdf#Graph
 
-  final def addTriples(mgraph: Rdf#MGraph, triples: TraversableOnce[Rdf#Triple]): mgraph.type = {
-    triples.foreach(triple => addTriple(mgraph, triple))
+  final def addTriples(mgraph: Rdf#MGraph, triples: IterableOnce[Rdf#Triple]): mgraph.type = {
+    triples.iterator.foreach(triple => addTriple(mgraph, triple))
     mgraph
   }
 
-  final def removeTriples(mgraph: Rdf#MGraph, triples: TraversableOnce[Rdf#Triple]): mgraph.type = {
-    triples.foreach(triple => removeTriple(mgraph, triple))
+  final def removeTriples(mgraph: Rdf#MGraph, triples: IterableOnce[Rdf#Triple]): mgraph.type = {
+    triples.iterator.foreach(triple => removeTriple(mgraph, triple))
     mgraph
   }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/PointedGraphs.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/PointedGraphs.scala
@@ -14,7 +14,7 @@ class PointedGraphs[Rdf <: RDF](val nodes: Iterable[Rdf#Node], val graph: Rdf#Gr
   def iterator = nodes.iterator map { PointedGraph(_, graph) }
 
   def /(p: Rdf#URI)(implicit ops: RDFOps[Rdf]): PointedGraphs[Rdf] = {
-    val ns: Iterable[Rdf#Node] = this flatMap { pointed: PointedGraph[Rdf] =>
+    val ns: Iterable[Rdf#Node] = this flatMap { (pointed: PointedGraph[Rdf]) =>
       import pointed.pointer
       ops.getObjects(graph, pointer, p)
     }
@@ -26,7 +26,7 @@ class PointedGraphs[Rdf <: RDF](val nodes: Iterable[Rdf#Node], val graph: Rdf#Gr
     if (!it.hasNext) {
       Failure(WrongExpectation("expected exactly one node but got 0"))
     } else {
-      val first = it.next
+      val first = it.next()
       Success(PointedGraph(first, graph))
     }
   }
@@ -39,7 +39,7 @@ class PointedGraphs[Rdf <: RDF](val nodes: Iterable[Rdf#Node], val graph: Rdf#Gr
     if (!it.hasNext) {
       Failure(WrongExpectation("expected exactly one node but got 0"))
     } else {
-      val first = it.next
+      val first = it.next()
       if (it.hasNext)
         Failure(WrongExpectation("expected exactly one node but got more than 1"))
       else

--- a/rdf/shared/src/main/scala/org/w3/banana/Prefix.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/Prefix.scala
@@ -356,6 +356,7 @@ trait CommonPrefixes[Rdf <: RDF] { this: RDFOps[Rdf] =>
 
   lazy val xsd = XSDPrefix(this)
   lazy val rdf = RDFPrefix(this)
+  lazy val owl = OWLPrefix(this)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/RDFDSL.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/RDFDSL.scala
@@ -63,13 +63,16 @@ trait RDFDSL[Rdf <: RDF] { this: RDFOps[Rdf] =>
   // graph traversal
 
   def getObjects(graph: Rdf#Graph, subject: Rdf#Node, predicate: Rdf#URI): Iterable[Rdf#Node] =
-    find(graph, toConcreteNodeMatch(subject), toConcreteNodeMatch(predicate), ANY).map(t => fromTriple(t)._3).toIterable
+    find(graph, toConcreteNodeMatch(subject), toConcreteNodeMatch(predicate), ANY)
+      .map(t => fromTriple(t)._3).to(Iterable)
 
   def getPredicates(graph: Rdf#Graph, subject: Rdf#Node): Iterable[Rdf#URI] =
-    find(graph, toConcreteNodeMatch(subject), ANY, ANY).map(t => fromTriple(t)._2).toIterable
+    find(graph, toConcreteNodeMatch(subject), ANY, ANY)
+      .map(t => fromTriple(t)._2).to(Iterable)
 
   def getSubjects(graph: Rdf#Graph, predicate: Rdf#URI, obj: Rdf#Node): Iterable[Rdf#Node] =
-    find(graph, ANY, toConcreteNodeMatch(predicate), toConcreteNodeMatch(obj)).map(t => fromTriple(t)._1).toIterable
+    find(graph, ANY, toConcreteNodeMatch(predicate), toConcreteNodeMatch(obj))
+      .map(t => fromTriple(t)._1).to(Iterable)
 
   // TripleMatch
 

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/FromLiteral.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/FromLiteral.scala
@@ -12,11 +12,13 @@ trait FromLiteral[Rdf <: RDF, +T] {
 
 object FromLiteral {
 
-  implicit def LiteralFromLiteral[Rdf <: RDF] = new FromLiteral[Rdf, Rdf#Literal] {
-    def fromLiteral(literal: Rdf#Literal): Success[Rdf#Literal] = Success(literal)
-  }
+  implicit def LiteralFromLiteral[Rdf <: RDF]: FromLiteral[Rdf,Rdf#Literal] =
+    new FromLiteral[Rdf, Rdf#Literal] {
+      def fromLiteral(literal: Rdf#Literal): Success[Rdf#Literal] = Success(literal)
+    }
 
-  implicit def StringFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromLiteral[Rdf, String] {
+  implicit def StringFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromLiteral[Rdf,String] =
+    new FromLiteral[Rdf, String] {
     import ops._
     def fromLiteral(literal: Rdf#Literal): Try[String] = {
       val Literal(lexicalForm, datatype, _) = literal
@@ -27,7 +29,8 @@ object FromLiteral {
     }
   }
 
-  implicit def BooleanFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromLiteral[Rdf, Boolean] {
+  implicit def BooleanFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromLiteral[Rdf,Boolean] =
+    new FromLiteral[Rdf, Boolean] {
     import ops._
     def fromLiteral(literal: Rdf#Literal): Try[Boolean] = {
       val Literal(lexicalForm, datatype, _) = literal
@@ -43,7 +46,8 @@ object FromLiteral {
     }
   }
 
-  implicit def IntFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromLiteral[Rdf, Int] {
+  implicit def IntFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromLiteral[Rdf,Int] =
+    new FromLiteral[Rdf, Int] {
     import ops._
     def fromLiteral(literal: Rdf#Literal): Try[Int] = {
       val Literal(lexicalForm, datatype, _) = literal
@@ -59,7 +63,8 @@ object FromLiteral {
     }
   }
 
-  implicit def BigIntFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromLiteral[Rdf, BigInteger] {
+  implicit def BigIntFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromLiteral[Rdf,BigInteger] =
+    new FromLiteral[Rdf, BigInteger] {
     import ops._
     def fromLiteral(literal: Rdf#Literal): Try[BigInteger] = {
       val Literal(lexicalForm, datatype, _) = literal
@@ -75,7 +80,8 @@ object FromLiteral {
     }
   }
 
-  implicit def DoubleFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromLiteral[Rdf, Double] {
+  implicit def DoubleFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromLiteral[Rdf,Double] =
+    new FromLiteral[Rdf, Double] {
     import ops._
     def fromLiteral(literal: Rdf#Literal): Try[Double] = {
       val Literal(lexicalForm, datatype, _) = literal
@@ -109,7 +115,8 @@ object FromLiteral {
     }
   }
 */
-  implicit def ByteArrayFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromLiteral[Rdf, Array[Byte]] {
+  implicit def ByteArrayFromLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromLiteral[Rdf,Array[Byte]] =
+    new FromLiteral[Rdf, Array[Byte]] {
     import ops._
     val whitespace = "\\s".r
     def hex2Bytes(hex: String): Try[Array[Byte]] = Try {

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/FromNode.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/FromNode.scala
@@ -10,15 +10,17 @@ trait FromNode[Rdf <: RDF, +T] {
 
 object FromNode {
 
-  implicit def PointedGraphFromNode[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new FromNode[Rdf, PointedGraph[Rdf]] {
+  implicit def PointedGraphFromNode[Rdf <: RDF](implicit ops: RDFOps[Rdf]): FromNode[Rdf,PointedGraph[Rdf]] =
+    new FromNode[Rdf, PointedGraph[Rdf]] {
     def fromNode(node: Rdf#Node): Try[PointedGraph[Rdf]] = Success(PointedGraph(node))
   }
 
-  implicit def NodeFromNode[Rdf <: RDF] = new FromNode[Rdf, Rdf#Node] {
+  implicit def NodeFromNode[Rdf <: RDF]: FromNode[Rdf,Rdf#Node] =
+    new FromNode[Rdf, Rdf#Node] {
     def fromNode(node: Rdf#Node): Try[Rdf#Node] = Success(node)
   }
 
-  implicit def FromURIFromNode[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], from: FromURI[Rdf, T]) =
+  implicit def FromURIFromNode[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], from: FromURI[Rdf, T]): FromNode[Rdf,T] =
     new FromNode[Rdf, T] {
       def fromNode(node: Rdf#Node): Try[T] = ops.foldNode(node)(
         uri => from.fromURI(uri),
@@ -27,7 +29,8 @@ object FromNode {
       )
     }
 
-  implicit def FromLiteralFromNode[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], from: FromLiteral[Rdf, T]) = new FromNode[Rdf, T] {
+  implicit def FromLiteralFromNode[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], from: FromLiteral[Rdf, T]): FromNode[Rdf,T] =
+    new FromNode[Rdf, T] {
     def fromNode(node: Rdf#Node): Try[T] = ops.foldNode(node)(
       uri => Failure(FailedConversion(s"expected Literal, got URI: $uri")),
       bnode => Failure(FailedConversion(s"expected Literal, got BNode: $bnode")),

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/FromPG.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/FromPG.scala
@@ -13,17 +13,18 @@ trait FromPG[Rdf <: RDF, +T] {
 
 object FromPG {
 
-  implicit def PointedGraphFromPG[Rdf <: RDF] =
+  implicit def PointedGraphFromPG[Rdf <: RDF]: FromPG[Rdf,PointedGraph[Rdf]] =
     new FromPG[Rdf, PointedGraph[Rdf]] {
       def fromPG(pointed: PointedGraph[Rdf]): Try[PointedGraph[Rdf]] = Success(pointed)
     }
 
-  implicit def FromNodeFromPG[Rdf <: RDF, T](implicit from: FromNode[Rdf, T]) =
+  implicit def FromNodeFromPG[Rdf <: RDF, T](implicit from: FromNode[Rdf, T]): FromPG[Rdf,T] =
     new FromPG[Rdf, T] {
       def fromPG(pointed: PointedGraph[Rdf]): Try[T] = from.fromNode(pointed.pointer)
     }
 
-  implicit def ListFromPG[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], from: FromPG[Rdf, T]): FromPG[Rdf, List[T]] = new FromPG[Rdf, List[T]] {
+  implicit def ListFromPG[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], from: FromPG[Rdf, T]): FromPG[Rdf, List[T]] =
+    new FromPG[Rdf, List[T]] {
     import ops._
     def fromPG(pointed: PointedGraph[Rdf]): Try[List[T]] = {
       import pointed.{ graph, pointer }
@@ -45,7 +46,11 @@ object FromPG {
     }
   }
 
-  implicit def EitherFromPG[Rdf <: RDF, T1, T2](implicit ops: RDFOps[Rdf], fromPG1: FromPG[Rdf, T1], fromPG2: FromPG[Rdf, T2]): FromPG[Rdf, Either[T1, T2]] = new FromPG[Rdf, Either[T1, T2]] {
+  implicit def EitherFromPG[Rdf <: RDF, T1, T2](
+    implicit ops: RDFOps[Rdf],
+    fromPG1: FromPG[Rdf, T1],
+    fromPG2: FromPG[Rdf, T2]
+  ): FromPG[Rdf, Either[T1, T2]] = new FromPG[Rdf, Either[T1, T2]] {
     import ops._
     def fromPG(pointed: PointedGraph[Rdf]): Try[Either[T1, T2]] = {
       if (pointed isA rdf("Left"))
@@ -57,7 +62,11 @@ object FromPG {
     }
   }
 
-  implicit def Tuple2FromPG[Rdf <: RDF, T1, T2](implicit ops: RDFOps[Rdf], fromPG1: FromPG[Rdf, T1], fromPG2: FromPG[Rdf, T2]): FromPG[Rdf, (T1, T2)] = new FromPG[Rdf, (T1, T2)] {
+  implicit def Tuple2FromPG[Rdf <: RDF, T1, T2](
+    implicit ops: RDFOps[Rdf],
+    fromPG1: FromPG[Rdf, T1],
+    fromPG2: FromPG[Rdf, T2]
+  ): FromPG[Rdf, (T1, T2)] = new FromPG[Rdf, (T1, T2)] {
     import ops._
     def fromPG(pointed: PointedGraph[Rdf]): Try[(T1, T2)] = {
       for {
@@ -67,13 +76,20 @@ object FromPG {
     }
   }
 
-  implicit def MapFromPG[Rdf <: RDF, K, V](implicit ops: RDFOps[Rdf], kFromPG: FromPG[Rdf, K], vFromPG: FromPG[Rdf, V]): FromPG[Rdf, Map[K, V]] = new FromPG[Rdf, Map[K, V]] {
+  implicit def MapFromPG[Rdf <: RDF, K, V](
+    implicit ops: RDFOps[Rdf],
+    kFromPG: FromPG[Rdf, K],
+    vFromPG: FromPG[Rdf, V]
+  ): FromPG[Rdf, Map[K, V]] = new FromPG[Rdf, Map[K, V]] {
     val ListKVFromPG = implicitly[FromPG[Rdf, List[(K, V)]]]
     def fromPG(pointed: PointedGraph[Rdf]): Try[Map[K, V]] =
       ListKVFromPG.fromPG(pointed) map { l => Map(l: _*) }
   }
 
-  implicit def OptionFromPG[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], from: FromPG[Rdf, T]): FromPG[Rdf, Option[T]] = new FromPG[Rdf, Option[T]] {
+  implicit def OptionFromPG[Rdf <: RDF, T](
+    implicit ops: RDFOps[Rdf],
+    from: FromPG[Rdf, T]
+  ): FromPG[Rdf, Option[T]] = new FromPG[Rdf, Option[T]] {
     val ListFromPG = implicitly[FromPG[Rdf, List[T]]]
     def fromPG(pointed: PointedGraph[Rdf]): Try[Option[T]] =
       ListFromPG.fromPG(pointed) map { _.headOption }

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/FromURI.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/FromURI.scala
@@ -10,7 +10,7 @@ trait FromURI[Rdf <: RDF, +T] {
 
 object FromURI {
 
-  implicit def URIFromURI[Rdf <: RDF] = new FromURI[Rdf, Rdf#URI] {
+  implicit def URIFromURI[Rdf <: RDF]: FromURI[Rdf,Rdf#URI] = new FromURI[Rdf, Rdf#URI] {
     def fromURI(uri: Rdf#URI): Try[Rdf#URI] = Success(uri)
   }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/RecordBinder.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/RecordBinder.scala
@@ -40,7 +40,7 @@ class RecordBinder[Rdf <: RDF]()(implicit ops: RDFOps[Rdf]) {
         if (constUri == uri)
           Success(constT)
         else
-          Failure(WrongExpectation(constUri + " does not equal " + uri))
+          Failure(WrongExpectation(String.valueOf(constUri) + " does not equal " + uri))
 
       def toURI(t: T): Rdf#URI = constUri
     }

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/RecordBinder.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/RecordBinder.scala
@@ -137,7 +137,9 @@ class RecordBinder[Rdf <: RDF]()(implicit ops: RDFOps[Rdf]) {
 
     }
 
-    def apply[T1, T2](p1: Property[Rdf, T1], p2: Property[Rdf, T2])(apply: (T1, T2) => T, unapply: T => Option[(T1, T2)]): PGBinder[Rdf, T] = new PGBinder[Rdf, T] {
+    def apply[T1, T2](p1: Property[Rdf, T1], p2: Property[Rdf, T2])
+                    (apply: (T1, T2) => T, unapply: T => Option[(T1, T2)]): PGBinder[Rdf, T] =
+      new PGBinder[Rdf, T] {
 
       def toPG(t: T): PointedGraph[Rdf] = {
         val Some((t1, t2)) = unapply(t)

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/ToLiteral.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/ToLiteral.scala
@@ -8,23 +8,23 @@ trait ToLiteral[Rdf <: RDF, -T] {
 
 object ToLiteral {
 
-  implicit def LiteralToLiteral[Rdf <: RDF] = new ToLiteral[Rdf, Rdf#Literal] {
+  implicit def LiteralToLiteral[Rdf <: RDF]: ToLiteral[Rdf,Rdf#Literal] = new ToLiteral[Rdf, Rdf#Literal] {
     def toLiteral(t: Rdf#Literal): Rdf#Literal = t
   }
 
-  implicit def StringToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) =
+  implicit def StringToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToLiteral[Rdf,String] =
     new ToLiteral[Rdf, String] {
       import ops._
       def toLiteral(s: String): Rdf#Literal = Literal(s, xsd.string)
     }
 
-  implicit def BooleanToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) =
+  implicit def BooleanToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToLiteral[Rdf,Boolean] =
     new ToLiteral[Rdf, Boolean] {
       import ops._
       def toLiteral(b: Boolean): Rdf#Literal = Literal(if (b) "true" else "false", xsd.boolean)
     }
 
-  implicit def IntToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) =
+  implicit def IntToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToLiteral[Rdf,Int] =
     new ToLiteral[Rdf, Int] {
       import ops._
       def toLiteral(i: Int): Rdf#Literal = Literal(i.toString, xsd.integer)
@@ -32,13 +32,13 @@ object ToLiteral {
 
   import java.math.BigInteger
 
-  implicit def BigIntToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) =
+  implicit def BigIntToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToLiteral[Rdf,BigInteger] =
     new ToLiteral[Rdf, BigInteger] {
       import ops._
       def toLiteral(i: BigInteger): Rdf#Literal = Literal(i.toString, xsd.integer)
     }
 
-  implicit def DoubleToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) =
+  implicit def DoubleToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToLiteral[Rdf,Double] =
     new ToLiteral[Rdf, Double] {
       import ops._
       def toLiteral(d: Double): Rdf#Literal = Literal(d.toString, xsd.double)
@@ -64,7 +64,7 @@ object ToLiteral {
     }
   */
 
-  implicit def ByteArrayToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]) =
+  implicit def ByteArrayToLiteral[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToLiteral[Rdf,Array[Byte]]{def bytes2Hex(bytes: Array[Byte]): String} =
     new ToLiteral[Rdf, Array[Byte]] {
       import ops._
       def bytes2Hex(bytes: Array[Byte]): String = {

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/ToNode.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/ToNode.scala
@@ -8,19 +8,19 @@ trait ToNode[Rdf <: RDF, -T] {
 
 object ToNode {
 
-  implicit def PointedGraphToNode[Rdf <: RDF] = new ToNode[Rdf, PointedGraph[Rdf]] {
+  implicit def PointedGraphToNode[Rdf <: RDF]: ToNode[Rdf,PointedGraph[Rdf]] = new ToNode[Rdf, PointedGraph[Rdf]] {
     def toNode(t: PointedGraph[Rdf]): Rdf#Node = t.pointer
   }
 
-  implicit def NodeToNode[Rdf <: RDF] = new ToNode[Rdf, Rdf#Node] {
+  implicit def NodeToNode[Rdf <: RDF]: ToNode[Rdf,Rdf#Node] = new ToNode[Rdf, Rdf#Node] {
     def toNode(t: Rdf#Node): Rdf#Node = t
   }
 
-  implicit def ToLiteralToNode[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], to: ToLiteral[Rdf, T]) = new ToNode[Rdf, T] {
+  implicit def ToLiteralToNode[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], to: ToLiteral[Rdf, T]): ToNode[Rdf,T] = new ToNode[Rdf, T] {
     def toNode(t: T): Rdf#Node = to.toLiteral(t)
   }
 
-  implicit def ToURIToNode[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], to: ToURI[Rdf, T]) = new ToNode[Rdf, T] {
+  implicit def ToURIToNode[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], to: ToURI[Rdf, T]): ToNode[Rdf,T] = new ToNode[Rdf, T] {
     def toNode(t: T): Rdf#Node = to.toURI(t)
   }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/ToPG.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/ToPG.scala
@@ -11,11 +11,11 @@ trait ToPG[Rdf <: RDF, -T] {
 
 object ToPG {
 
-  implicit def PointedGraphToPG[Rdf <: RDF] = new ToPG[Rdf, PointedGraph[Rdf]] {
+  implicit def PointedGraphToPG[Rdf <: RDF]: ToPG[Rdf,PointedGraph[Rdf]] = new ToPG[Rdf, PointedGraph[Rdf]] {
     def toPG(t: PointedGraph[Rdf]): PointedGraph[Rdf] = t
   }
 
-  implicit def ToNodeToPG[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], to: ToNode[Rdf, T]) = new ToPG[Rdf, T] {
+  implicit def ToNodeToPG[Rdf <: RDF, T](implicit ops: RDFOps[Rdf], to: ToNode[Rdf, T]): ToPG[Rdf,T] = new ToPG[Rdf, T] {
     def toPG(t: T): PointedGraph[Rdf] = PointedGraph(to.toNode(t))
   }
 
@@ -28,7 +28,7 @@ object ToPG {
         val newBNode = bnode()
         val pointed = to.toPG(a)
         triples += Triple(newBNode, rdf.first, pointed.pointer)
-        triples ++= pointed.graph.triples
+        triples ++= ops.graphW(pointed.graph).triples
         triples += Triple(newBNode, rdf.rest, current)
         current = newBNode
       }

--- a/rdf/shared/src/main/scala/org/w3/banana/binder/ToURI.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/binder/ToURI.scala
@@ -8,15 +8,15 @@ trait ToURI[Rdf <: RDF, -T] {
 
 object ToURI {
 
-  implicit def URIToURI[Rdf <: RDF] = new ToURI[Rdf, Rdf#URI] {
+  implicit def URIToURI[Rdf <: RDF]: ToURI[Rdf,Rdf#URI] = new ToURI[Rdf, Rdf#URI] {
     def toURI(t: Rdf#URI): Rdf#URI = t
   }
 
-  implicit def javaURLToURI[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new ToURI[Rdf, java.net.URL] {
+  implicit def javaURLToURI[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToURI[Rdf,java.net.URL] = new ToURI[Rdf, java.net.URL] {
     def toURI(t: java.net.URL): Rdf#URI = ops.URI(t.toString)
   }
 
-  implicit def javaURIToURI[Rdf <: RDF](implicit ops: RDFOps[Rdf]) = new ToURI[Rdf, java.net.URI] {
+  implicit def javaURIToURI[Rdf <: RDF](implicit ops: RDFOps[Rdf]): ToURI[Rdf,java.net.URI] = new ToURI[Rdf, java.net.URI] {
     def toURI(t: java.net.URI): Rdf#URI = ops.URI(t.toString)
   }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/diesel/ObjectList.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/diesel/ObjectList.scala
@@ -1,7 +1,7 @@
 package org.w3.banana.diesel
 
-class ObjectList[T](val ts: Traversable[T]) extends AnyVal {}
+class ObjectList[T](val ts: Iterable[T]) extends AnyVal {}
 
 object ObjectList {
-  def apply[T](ts: Traversable[T]): ObjectList[T] = new ObjectList[T](ts)
+  def apply[T](ts: Iterable[T]): ObjectList[T] = new ObjectList[T](ts)
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/diesel/PointedGraphPredicate.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/diesel/PointedGraphPredicate.scala
@@ -9,7 +9,7 @@ class PointedGraphPredicate[Rdf <: RDF](pointed: PointedGraph[Rdf], p: Rdf#URI) 
     import ops._
     import pointed.{ graph => acc, pointer => s }
     import pointedObject.{ graph => graphObject, pointer => o }
-    val graph = Graph(Triple(s, p, o)) union acc union graphObject
+    val graph = ops.graphW(ops.graphW(Graph(Triple(s, p, o))) union acc) union graphObject
     PointedGraph(s, graph)
   }
 
@@ -38,7 +38,7 @@ class PointedGraphPredicate[Rdf <: RDF](pointed: PointedGraph[Rdf], p: Rdf#URI) 
     val graph = objects.foldLeft(pointed.graph) {
       case (acc, obj) =>
         val pg = toPG.toPG(obj)
-        acc union Graph(Set(Triple(pointed.pointer, p, pg.pointer))) union pg.graph
+        ops.graphW(ops.graphW(acc) union Graph(Set(Triple(pointed.pointer, p, pg.pointer)))) union pg.graph
     }
     PointedGraph(pointed.pointer, graph)
   }

--- a/rdf/shared/src/main/scala/org/w3/banana/diesel/PointedGraphW.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/diesel/PointedGraphW.scala
@@ -50,9 +50,9 @@ class PointedGraphW[Rdf <: RDF](val pointed: PointedGraph[Rdf]) extends AnyVal {
       classes exists { _ == clazz }
     }
     pointer.fold(
-      uri => isAIfNodeOrBNode,
-      bnode => isAIfNodeOrBNode,
-      literal => false
+      (uri: Rdf#URI) => isAIfNodeOrBNode,
+      (bnode: Rdf#BNode) => isAIfNodeOrBNode,
+      (literal: Rdf#Literal) => false
     )
   }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/diesel/PredicatePointedGraph.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/diesel/PredicatePointedGraph.scala
@@ -7,7 +7,7 @@ case class PredicatePointedGraph[Rdf <: RDF](p: Rdf#URI, pointed: PointedGraph[R
   def --(s: Rdf#Node)(implicit ops: RDFOps[Rdf]): PointedGraph[Rdf] = {
     import ops._
     import pointed.{ graph => acc, pointer => o }
-    val graph = acc union Graph(Triple(s, p, o))
+    val graph = ops.graphW(acc) union Graph(Triple(s, p, o))
     PointedGraph(s, graph)
   }
 
@@ -15,7 +15,7 @@ case class PredicatePointedGraph[Rdf <: RDF](p: Rdf#URI, pointed: PointedGraph[R
     import ops._
     import pointed.{ graph => acc, pointer => o }
     import pointedSubject.{ graph => graphObject, pointer => s }
-    val graph = Graph(Triple(s, p, o)) union acc union graphObject
+    val graph = ops.graphW(ops.graphW(Graph(Triple(s, p, o))) union acc) union graphObject
     PointedGraph(s, graph)
   }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/io/BooleanWriter.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/BooleanWriter.scala
@@ -20,8 +20,8 @@ object BooleanWriter {
   /**
    * <a href="http://www.w3.org/TR/sparql11-results-json/">Sparql 1.1 Query Results JSON Format</a>
    */
-  implicit val Json = new BooleanWriter[SparqlAnswerJson] {
-
+  implicit val Json: BooleanWriter[SparqlAnswerJson] =
+    new BooleanWriter[SparqlAnswerJson] {
     def format(bool: Boolean): String =
       """{
         |  "head": {},
@@ -29,15 +29,15 @@ object BooleanWriter {
         |}
         | """.stripMargin.format(bool)
 
-    override def write(obj: Boolean, outputstream: OutputStream, base: String) = ???
+    override def write(obj: Boolean, outputstream: OutputStream, base: String) : Try[Unit] = ???
 
   }
 
   /**
    * <a href="http://www.w3.org/TR/rdf-sparql-XMLres/">Sparql Query Results XML Format</a>
    */
-  implicit val booleanWriterXml = new BooleanWriter[SparqlAnswerXml] {
-
+  implicit val booleanWriterXml: BooleanWriter[SparqlAnswerXml]  =
+    new BooleanWriter[SparqlAnswerXml] {
     def format(bool: Boolean): String =
       """<?xml version="1.0"?>
         |<sparql xmlns="http://www.w3.org/2005/sparql-results#">
@@ -45,7 +45,7 @@ object BooleanWriter {
         |  <boolean>%s</boolean>
         |</sparql> """.stripMargin.format(bool) // "
 
-    override def write(obj: Boolean, outputstream: OutputStream, base: String) = ???
+    override def write(obj: Boolean, outputstream: OutputStream, base: String): Try[Unit] = ???
   }
 
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/isomorphism/VerticeClassification.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/isomorphism/VerticeClassification.scala
@@ -69,8 +69,7 @@ class CountingVCBuilder[Rdf <: RDF]
 
 }
 
-case class CountingVC(forwardRels: Int,
-  backwardRels: Int) extends VerticeClassification
+case class CountingVC(forwardRels: Int, backwardRels: Int) extends VerticeClassification
 
 /**
  *

--- a/rdf/shared/src/main/scala/org/w3/banana/package.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/package.scala
@@ -23,8 +23,8 @@ package object banana {
    * @return the Execution Context
    */
   def sameThreadExecutionContext = new ExecutionContext {
-    def reportFailure(t: Throwable) { t.printStackTrace() }
-    def execute(runnable: Runnable) { runnable.run() }
+    def reportFailure(t: Throwable): Unit = { t.printStackTrace() }
+    def execute(runnable: Runnable): Unit = { runnable.run() }
   }
 
   implicit class TryW[T](t: Try[T]) {

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/GraphStoreSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/GraphStoreSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 final class GraphStoreSyntax[Rdf <: RDF, M[+_], A] {
 
-  implicit def graphStoreW(a: A) = new GraphStoreW[Rdf, M, A](a)
+  implicit def graphStoreW(a: A): GraphStoreW[Rdf,M,A] = new GraphStoreW[Rdf, M, A](a)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/GraphSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/GraphSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait GraphSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def graphW(graph: Rdf#Graph) = new GraphW[Rdf](graph)
+  implicit def graphW(graph: Rdf#Graph): GraphW[Rdf] = new GraphW[Rdf](graph)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/LifecycleSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/LifecycleSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 final class LifecycleSyntax[Rdf <: RDF, A] {
 
-  implicit def lifecycleW(a: A) = new LifecycleW[Rdf, A](a)
+  implicit def lifecycleW(a: A): LifecycleW[Rdf,A] = new LifecycleW[Rdf, A](a)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/LiteralSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/LiteralSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait LiteralSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def literalW(literal: Rdf#Literal) =
+  implicit def literalW(literal: Rdf#Literal): LiteralW[Rdf] =
     new LiteralW[Rdf](literal)
 
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/MGraphSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/MGraphSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait MGraphSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def mgraphW(mgraph: Rdf#MGraph) = new MGraphW[Rdf](mgraph)
+  implicit def mgraphW(mgraph: Rdf#MGraph): MGraphW[Rdf] = new MGraphW[Rdf](mgraph)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/MGraphSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/MGraphSyntax.scala
@@ -13,13 +13,13 @@ class MGraphW[Rdf <: RDF](val mgraph: Rdf#MGraph) extends AnyVal {
   def +=(triple: Rdf#Triple)(implicit ops: RDFOps[Rdf]): mgraph.type =
     ops.addTriple(mgraph, triple)
 
-  def ++=(triples: TraversableOnce[Rdf#Triple])(implicit ops: RDFOps[Rdf]): mgraph.type =
+  def ++=(triples: IterableOnce[Rdf#Triple])(implicit ops: RDFOps[Rdf]): mgraph.type =
     ops.addTriples(mgraph, triples)
 
   def -=(triple: Rdf#Triple)(implicit ops: RDFOps[Rdf]): mgraph.type =
     try ops.removeTriple(mgraph, triple) catch { case e: NoSuchElementException => mgraph }
 
-  def --=(triples: TraversableOnce[Rdf#Triple])(implicit ops: RDFOps[Rdf]): mgraph.type =
+  def --=(triples: IterableOnce[Rdf#Triple])(implicit ops: RDFOps[Rdf]): mgraph.type =
     ops.removeTriples(mgraph, triples)
 
   def exists(triple: Rdf#Triple)(implicit ops: RDFOps[Rdf]): Boolean =

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/NodeMatchSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/NodeMatchSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait NodeMatchSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def nodeMatchW(nodeMatch: Rdf#NodeMatch) =
+  implicit def nodeMatchW(nodeMatch: Rdf#NodeMatch): NodeMatchW[Rdf] =
     new NodeMatchW[Rdf](nodeMatch)
 
 }
@@ -16,12 +16,12 @@ class NodeMatchW[Rdf <: RDF](val nodeMatch: Rdf#NodeMatch) extends AnyVal {
 
   def resolveAgainst(baseUri: Rdf#URI)(implicit ops: RDFOps[Rdf]): Rdf#NodeMatch = {
     import ops._
-    ops.foldNodeMatch(nodeMatch)(ops.ANY, _.resolveAgainst(baseUri))
+    ops.foldNodeMatch(nodeMatch)(ops.ANY, node => node.resolveAgainst(baseUri))
   }
 
   def relativize(baseUri: Rdf#URI)(implicit ops: RDFOps[Rdf]): Rdf#NodeMatch = {
     import ops._
-    ops.foldNodeMatch(nodeMatch)(ops.ANY, _.relativize(baseUri))
+    ops.foldNodeMatch(nodeMatch)(ops.ANY, node => node.relativize(baseUri))
   }
 
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/NodeSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/NodeSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait NodeSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def nodeW(node: Rdf#Node) = new NodeW[Rdf](node)
+  implicit def nodeW(node: Rdf#Node): NodeW[Rdf] = new NodeW[Rdf](node)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/SolutionSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/SolutionSyntax.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 
 trait SolutionSyntax[Rdf <: RDF] { self: SolutionSyntax[Rdf] =>
 
-  implicit def solutionW(solution: Rdf#Solution) = new SolutionW[Rdf](solution)
+  implicit def solutionW(solution: Rdf#Solution): SolutionW[Rdf] = new SolutionW[Rdf](solution)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/SolutionsSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/SolutionsSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait SolutionsSyntax[Rdf <: RDF] { self: SolutionsSyntax[Rdf] =>
 
-  implicit def solutionsW(solutions: Rdf#Solutions) = new SolutionsW[Rdf](solutions)
+  implicit def solutionsW(solutions: Rdf#Solutions): SolutionsW[Rdf] = new SolutionsW[Rdf](solutions)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlEngineSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlEngineSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 final class SparqlEngineSyntax[Rdf <: RDF, M[_], A] {
 
-  implicit def sparqlEngineW(a: A) = new SparqlEngineW[Rdf, M, A](a)
+  implicit def sparqlEngineW(a: A): SparqlEngineW[Rdf,M,A] = new SparqlEngineW[Rdf, M, A](a)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlEngineSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlEngineSyntax.scala
@@ -10,13 +10,19 @@ final class SparqlEngineSyntax[Rdf <: RDF, M[_], A] {
 
 final class SparqlEngineW[Rdf <: RDF, M[_], A](val a: A) extends AnyVal {
 
-  def executeSelect(query: Rdf#SelectQuery, bindings: Map[String, Rdf#Node] = Map.empty)(implicit sparqlEngine: SparqlEngine[Rdf, M, A]) =
+  def executeSelect(query: Rdf#SelectQuery, bindings: Map[String, Rdf#Node] = Map.empty)(
+    implicit sparqlEngine: SparqlEngine[Rdf, M, A]
+  ): M[Rdf#Solutions] =
     sparqlEngine.executeSelect(a, query, bindings)
 
-  def executeConstruct(query: Rdf#ConstructQuery, bindings: Map[String, Rdf#Node] = Map.empty)(implicit sparqlEngine: SparqlEngine[Rdf, M, A]) =
+  def executeConstruct(query: Rdf#ConstructQuery, bindings: Map[String, Rdf#Node] = Map.empty)(
+    implicit sparqlEngine: SparqlEngine[Rdf, M, A]
+  ): M[Rdf#Graph] =
     sparqlEngine.executeConstruct(a, query, bindings)
 
-  def executeAsk(query: Rdf#AskQuery, bindings: Map[String, Rdf#Node] = Map.empty)(implicit sparqlEngine: SparqlEngine[Rdf, M, A]) =
+  def executeAsk(query: Rdf#AskQuery, bindings: Map[String, Rdf#Node] = Map.empty)(
+    implicit sparqlEngine: SparqlEngine[Rdf, M, A]
+  ): M[Boolean] =
     sparqlEngine.executeAsk(a, query, bindings)
 
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlQuerySyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlQuerySyntax.scala
@@ -6,7 +6,7 @@ import scala.util.Try
 
 trait SparqlQuerySyntax[Rdf <: RDF] { self: SparqlQuerySyntax[Rdf] =>
 
-  implicit def sparqlQueryW(query: Rdf#Query) = new SparqlQueryW[Rdf](query)
+  implicit def sparqlQueryW(query: Rdf#Query): SparqlQueryW[Rdf] = new SparqlQueryW[Rdf](query)
 
   def parseSelect(query: String)(implicit sparqlOps: SparqlOps[Rdf]): Try[Rdf#SelectQuery] =
     sparqlOps.parseSelect(query, Seq.empty)

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlSolutionSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlSolutionSyntax.scala
@@ -6,7 +6,7 @@ import scala.util._
 
 trait SparqlSolutionSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def sparqlSolutionSyntax(solution: Rdf#Solution) = new SparqlSolutionSyntaxW[Rdf](solution)
+  implicit def sparqlSolutionSyntax(solution: Rdf#Solution): SparqlSolutionSyntaxW[Rdf] = new SparqlSolutionSyntaxW[Rdf](solution)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlSolutionsSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlSolutionsSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait SparqlSolutionsSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def sparqlSolutionsSyntax(solutions: Rdf#Solutions) = new SparqlSolutionsSyntaxW[Rdf](solutions)
+  implicit def sparqlSolutionsSyntax(solutions: Rdf#Solutions): SparqlSolutionsSyntaxW[Rdf] = new SparqlSolutionsSyntaxW[Rdf](solutions)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlUpdateSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/SparqlUpdateSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 final class SparqlUpdateSyntax[Rdf <: RDF, M[_], A] {
 
-  implicit def sparqlUpdateSyntaxW(a: A) = new SparqlUpdateSyntaxW[Rdf, M, A](a)
+  implicit def sparqlUpdateSyntaxW(a: A): SparqlUpdateSyntaxW[Rdf,M,A] = new SparqlUpdateSyntaxW[Rdf, M, A](a)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/StringSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/StringSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait StringSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def stringW(s: String) = new StringW[Rdf](s)
+  implicit def stringW(s: String): StringW[Rdf] = new StringW[Rdf](s)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/TransactorSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/TransactorSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 final class TransactorSyntax[Rdf <: RDF, A] {
 
-  implicit def transactorW(a: A) = new TransactorW[Rdf, A](a)
+  implicit def transactorW(a: A): TransactorW[Rdf,A] = new TransactorW[Rdf, A](a)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/TripleMatchSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/TripleMatchSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait TripleMatchSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def tripleMatchW(tripleMatch: TripleMatch[Rdf]) =
+  implicit def tripleMatchW(tripleMatch: TripleMatch[Rdf]): TripleMatchW[Rdf] =
     new TripleMatchW[Rdf](tripleMatch)
 
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/TripleSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/TripleSyntax.scala
@@ -4,7 +4,7 @@ import org.w3.banana._
 
 trait TripleSyntax[Rdf <: RDF] { self: RDFSyntax[Rdf] =>
 
-  implicit def tripleSyntax(triple: Rdf#Triple) = new TripleW[Rdf](triple)
+  implicit def tripleSyntax(triple: Rdf#Triple): TripleW[Rdf] = new TripleW[Rdf](triple)
 
 }
 

--- a/rdf/shared/src/main/scala/org/w3/banana/util/TryInstances.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/util/TryInstances.scala
@@ -6,11 +6,11 @@ import scala.util.Try
 
 object tryInstances {
   implicit final val TryInstance: Monad[Try] with Comonad[Try] = new Monad[Try] with Comonad[Try] {
-    def point[A](a: => A): Try[A] = Try.apply[A](a)
+    def point[A](a: => A): Try[A] = Try[A](a)
     def bind[A, B](fa: Try[A])(f: A => Try[B]): Try[B] = fa flatMap f
     override def map[A, B](fa: Try[A])(f: A => B): Try[B] = fa map f
-    def cobind[A, B](fa: Try[A])(f: Try[A] => B): Try[B] = Try.apply[B](f(fa))
-    override def cojoin[A](a: Try[A]): Try[Try[A]] = Try.apply[Try[A]](a)
+    def cobind[A, B](fa: Try[A])(f: Try[A] => B): Try[B] = Try[B](f(fa))
+    override def cojoin[A](a: Try[A]): Try[Try[A]] = Try[Try[A]](a)
     def copoint[A](p: Try[A]): A = p.get
   }
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/util/TryInstances.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/util/TryInstances.scala
@@ -5,12 +5,12 @@ import scalaz.{ Monad, Comonad }
 import scala.util.Try
 
 object tryInstances {
-  implicit final val TryInstance = new Monad[Try] with Comonad[Try] {
-    def point[A](a: => A): Try[A] = Try(a)
+  implicit final val TryInstance: Monad[Try] with Comonad[Try] = new Monad[Try] with Comonad[Try] {
+    def point[A](a: => A): Try[A] = Try.apply[A](a)
     def bind[A, B](fa: Try[A])(f: A => Try[B]): Try[B] = fa flatMap f
     override def map[A, B](fa: Try[A])(f: A => B): Try[B] = fa map f
-    def cobind[A, B](fa: Try[A])(f: Try[A] => B): Try[B] = Try(f(fa))
-    override def cojoin[A](a: Try[A]): Try[Try[A]] = Try(a)
+    def cobind[A, B](fa: Try[A])(f: Try[A] => B): Try[B] = Try.apply[B](f(fa))
+    override def cojoin[A](a: Try[A]): Try[Try[A]] = Try.apply[Try[A]](a)
     def copoint[A](p: Try[A]): A = p.get
   }
 }

--- a/rdf4j/src/main/scala/org/w3/banana/rdf4j/Rdf4jModule.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rdf4j/Rdf4jModule.scala
@@ -47,7 +47,7 @@ trait Rdf4jModule
 
   implicit val jsonldReader: RDFReader[Rdf, Try, JsonLd] = new Rdf4jJSONLDReader
 
-  implicit val rdf4jRDFWriterHelper = new Rdf4jRDFWriterHelper
+  implicit val rdf4jRDFWriterHelper: Rdf4jRDFWriterHelper = new Rdf4jRDFWriterHelper
 
   implicit val rdfXMLWriter: RDFWriter[Rdf4j, Try, RDFXML] = rdf4jRDFWriterHelper.rdfxmlWriter
 

--- a/rdf4j/src/main/scala/org/w3/banana/rdf4j/Rdf4jOps.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rdf4j/Rdf4jOps.scala
@@ -7,7 +7,7 @@ import org.eclipse.rdf4j.model.impl._
 import org.eclipse.rdf4j.model.util._
 import org.w3.banana._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class Rdf4jOps extends RDFOps[Rdf4j] with Rdf4jMGraphOps with DefaultURIOps[Rdf4j] {
 

--- a/rdf4j/src/main/scala/org/w3/banana/rdf4j/Rdf4jSparqlOps.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rdf4j/Rdf4jSparqlOps.scala
@@ -5,7 +5,7 @@ import org.eclipse.rdf4j.query.parser.{ ParsedBooleanQuery, ParsedGraphQuery, Pa
 import org.w3.banana.SparqlOps.withPrefixes
 import org.w3.banana._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util._
 
 object Rdf4jSparqlOps extends SparqlOps[Rdf4j] {

--- a/rdf4j/src/main/scala/org/w3/banana/rdf4j/Rdf4jStore.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rdf4j/Rdf4jStore.scala
@@ -6,7 +6,7 @@ import org.eclipse.rdf4j.query._
 import org.eclipse.rdf4j.repository.{RepositoryConnection, RepositoryResult}
 import org.w3.banana._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 class Rdf4jStore

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.5-SNAPSHOT"
+version in ThisBuild := "0.9.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.9.0-SNAPSHOT"
+ThisBuild / version := "0.8.5-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.0-SNAPSHOT"
+ThisBuild / version := "0.9.0-SNAPSHOT"


### PR DESCRIPTION
Get as close to Scala3 as possible. 
Scala 3 requiring projections will make the full move quite difficult, but this is a first step to help explore ideas. The remaining 510 errors if switching to Scala3 are due to type projections.
