### PR TITLE
make rdfWriter base Optional

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val publicationSettings = {
 
 lazy val commonSettings = publicationSettings ++ scalariformSettings ++ Seq(
   organization := "net.bblfish.rdf",
-  scalaVersion := "2.13.5", //"3.0.0-RC2",
+  scalaVersion := "2.13.6", //"3.0.0-RC2",
   resolvers += "apache-repo-releases" at "https://repository.apache.org/content/repositories/releases/",
   fork := false,
   Test / parallelExecution := false,

--- a/jena/src/main/scala/org/w3/banana/jena/JenaOps.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaOps.scala
@@ -25,7 +25,6 @@ class JenaOps extends RDFOps[Jena] with JenaMGraphOps with DefaultURIOps[Jena] {
     graph.find(JenaNode.ANY, JenaNode.ANY, JenaNode.ANY).asScala.to(Iterable)
 
   // triple
-
   def makeTriple(s: Jena#Node, p: Jena#URI, o: Jena#Node): Jena#Triple = {
     JenaTriple.create(s, p, o)
   }
@@ -78,7 +77,7 @@ class JenaOps extends RDFOps[Jena] with JenaMGraphOps with DefaultURIOps[Jena] {
   // TODO the javadoc doesn't say if this is thread safe
   lazy val mapper = TypeMapper.getInstance
 
-  def jenaDatatype(datatype: Jena#URI) = {
+  def jenaDatatype(datatype: Jena#URI): RDFDatatype = {
     val iriString = fromUri(datatype)
     val typ = mapper.getTypeByName(iriString)
     if (typ == null) {
@@ -118,9 +117,9 @@ class JenaOps extends RDFOps[Jena] with JenaMGraphOps with DefaultURIOps[Jena] {
 
   // lang
 
-  def makeLang(langString: String) = langString
+  def makeLang(langString: String): Jena#Lang = langString
 
-  def fromLang(lang: Jena#Lang) = lang
+  def fromLang(lang: Jena#Lang): String = lang
 
   // graph traversal
 

--- a/jena/src/main/scala/org/w3/banana/jena/JenaUtil.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/JenaUtil.scala
@@ -23,7 +23,7 @@ class JenaUtil(implicit jenaOps: RDFOps[Jena]) {
   def dump[Rdf <: RDF](graph: Rdf#Graph)(implicit ops: RDFOps[Rdf]): Unit = {
     val mToJena = new RDFTransformer[Rdf, Jena](ops, jenaOps)
     val jenaGraph = mToJena.transform(graph)
-    println(JenaRDFWriter.turtleWriter.asString(jenaGraph, ""))
+    println(JenaRDFWriter.turtleWriter.asString(jenaGraph, None))
   }
 
   def copy(graph: Jena#Graph): Jena#Graph = {

--- a/jena/src/main/scala/org/w3/banana/jena/io/JenaSolutionsWriter.scala
+++ b/jena/src/main/scala/org/w3/banana/jena/io/JenaSolutionsWriter.scala
@@ -15,11 +15,11 @@ object JenaSolutionsWriter {
     jenaSparqlSyntax: JenaAnswerOutput[T]
   ): SparqlSolutionsWriter[Jena, T] = new SparqlSolutionsWriter[Jena, T] {
 
-    def write(answers: Jena#Solutions, os: OutputStream, base: String) = Try {
+    def write(answers: Jena#Solutions, os: OutputStream, base: Option[String]) = Try {
       ResultSetMgr.write(os,answers,jenaSparqlSyntax.formatter)
     }
 
-    def asString(answers: Jena#Solutions, base: String): Try[String] = Try {
+    def asString(answers: Jena#Solutions, base: Option[String]): Try[String] = Try {
       val result = new ByteArrayOutputStream()
       ResultSetMgr.write(result, answers, jenaSparqlSyntax.formatter)
       result.toString

--- a/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
+++ b/jena/src/test/scala/org/w3/banana/jena/JenaSerialisationTest.scala
@@ -1,11 +1,13 @@
 package org.w3.banana.jena
 
-import org.w3.banana.io.{NTriplesReaderTestSuite, PrefixTestSuite, RdfXMLTestSuite, TurtleTestSuite}
+import org.w3.banana.io._
 import org.w3.banana.util.tryInstances._
 
 import scala.util.Try
 
 class JenaTurtleTest extends TurtleTestSuite[Jena, Try]
+
+class JenaRelativeTurtleTest extends RelativeTurtleTestSuite[Jena, Try]
 
 class JenaPrefixTest extends PrefixTestSuite[Jena, Try]
 

--- a/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
+++ b/misc/examples/src/main/scala/org/w3/banana/examples/IOExample.scala
@@ -45,7 +45,7 @@ trait IOExample extends IOExampleDependencies {
 
     val tmpFile = new File(Properties.tmpDir, "card.ttl")
     val to = new java.io.FileOutputStream(tmpFile)
-    val ret = rdfXMLWriter.write(graph, to, base = timblCard)
+    val ret = rdfXMLWriter.write(graph, to, base = Some(timblCard))
     if (ret.isSuccess)
       println(s"successfuly wrote TimBL's card to ${tmpFile.getAbsolutePath}")
 
@@ -54,10 +54,10 @@ trait IOExample extends IOExampleDependencies {
     /* prints 10 triples to stdout */
 
     val graph10Triples = Graph(graph.triples.take(10).toSet)
-    val graphAsXMLString = rdfXMLWriter.asString(graph10Triples, base = timblCard) getOrElse sys.error("coudn't serialize the graph")
+    val graphAsXMLString = rdfXMLWriter.asString(graph10Triples, base = Some(timblCard)) getOrElse sys.error("coudn't serialize the graph")
     println(graphAsXMLString)
 
-    val graphAsTurtleString = turtleWriter.asString(graph10Triples, base = timblCard, Set(foaf, rdf)) getOrElse sys.error("coudn't serialize the graph")
+    val graphAsTurtleString = turtleWriter.asString(graph10Triples, base = Some(timblCard), Set(foaf, rdf)) getOrElse sys.error("coudn't serialize the graph")
     println(graphAsTurtleString)
   }
 

--- a/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
+++ b/ntriples/shared/src/main/scala/org/w3/banana/io/NTriplesWriter.scala
@@ -33,14 +33,14 @@ class NTriplesWriter[Rdf <: RDF](implicit val ops:RDFOps[Rdf]) extends RDFWriter
     }
   )
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Rdf]]): Try[Unit] = Try {
+  def write(graph: Rdf#Graph, os: OutputStream, base: Option[String], prefixes: Set[Prefix[Rdf]]): Try[Unit] = Try {
     for (triple <- graph.triples) {
       val line = tripleAsString(triple) + "\r\n"
       os.write(line.getBytes("UTF-8"))
     }
   }
 
-  def asString(graph: Rdf#Graph, base: String, prefixes: Set[Prefix[Rdf]]): Try[String] = Try{
+  def asString(graph: Rdf#Graph, base: Option[String], prefixes: Set[Prefix[Rdf]]): Try[String] = Try{
     (
       for ( triple <- ops.getTriples(graph))
       yield tripleAsString(triple)

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainURIOps.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/PlantainURIOps.scala
@@ -28,9 +28,9 @@ trait PlantainURIOps extends URIOps[Plantain] {
   /** TODO: avoid going through Java
    * for implementation algorithm, see [[https://github.com/stain/cxf/blob/trunk/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/utils/HttpUtils.java  HttpUtils.java]]
    */
-  def relativize(uri: Plantain#URI, other: Plantain#URI): Plantain#URI = {
+  def relativize(base: Plantain#URI, other: Plantain#URI): Plantain#URI = {
     import java.net.{URI => jURI}
-    val juri = new jURI(uri.toString).relativize(new jURI(other.toString))
+    val juri = new jURI(base.toString).relativize(new jURI(other.toString))
     Uri(juri.toString)
   }
 

--- a/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
+++ b/plantain/jvm/src/main/scala/org/w3/banana/plantain/io/PlantainRDFWriter.scala
@@ -25,12 +25,13 @@ object PlantainTurtleWriter extends RDFWriter[Plantain, Try, Turtle] {
     override def toString(): String = uri
   }
 
-  class Writer(graph: Plantain#Graph, outputstream: OutputStream, base: String) {
-    val baseUri = new jURI(base)
+  class Writer(graph: Plantain#Graph, outputstream: OutputStream, base: Option[String]) {
+    val baseUri: Option[jURI] = base.map(b => new jURI(b))
 
     object Uri {
       def unapply(node: Plantain#Node): Option[jURI] = node match {
-        case uri: Plantain#URI => Some(baseUri.relativize(new jURI(uri.toString)))
+        case uri: Plantain#URI =>
+          baseUri.map(bs=> bs.relativize(new jURI(uri.toString))).orElse(Some(new jURI(uri.toString)))
         case _                 => None
       }
     }
@@ -70,12 +71,12 @@ object PlantainTurtleWriter extends RDFWriter[Plantain, Try, Turtle] {
 
   }
 
-  def write(graph: Plantain#Graph, outputstream: OutputStream, base: String, prefixes: Set[Prefix[Plantain]]): Try[Unit] = {
+  def write(graph: Plantain#Graph, outputstream: OutputStream, base: Option[String], prefixes: Set[Prefix[Plantain]]): Try[Unit] = {
     val writer = new Writer(graph, outputstream, base)
     writer.write()
   }
 
-  def asString(graph: Plantain#Graph, base: String, prefixes: Set[Prefix[Plantain]]): Try[String] = Try {
+  def asString(graph: Plantain#Graph, base: Option[String], prefixes: Set[Prefix[Plantain]]): Try[String] = Try {
     val result = new ByteArrayOutputStream()
     val writer = new Writer(graph, result, base)
     writer.write()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,29 +17,29 @@ object Dependencies {
    * @see https://joda-time.sourceforge.net
    * @see https://repo1.maven.org/maven2/joda-time/joda-time/
    */
-  val jodaTime = "joda-time" % "joda-time" % "2.9.6"
+  val jodaTime = "joda-time" % "joda-time" % "2.10.10"
 
   /**
    * joda-convert
    * @see https://joda-convert.sourceforge.net
    * @see https://repo1.maven.org/maven2/org/joda/joda-convert
    */
-  val jodaConvert = "org.joda" % "joda-convert" % "1.8.1"
+  val jodaConvert = "org.joda" % "joda-convert" % "2.2.1"
 
   /**
    * scalatest
    * @see https://www.scalatest.org
    * @see https://repo1.maven.org/maven2/org/scalatest
    */
-  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.8")
+  val scalatest = Def.setting("org.scalatest" %%% "scalatest" % "3.2.9")
 
   /**
    * Akka Http Core
    * @see https://akka.io
    * @see https://repo1.maven.org/maven2/com/typesafe/akka
    */
-  val akkaHttpCore = ("com.typesafe.akka" %% "akka-http-core" % "10.2.4") cross CrossVersion.for3Use2_13
-  val akka = ("com.typesafe.akka" %% "akka-actor-typed" % "2.6.14") cross CrossVersion.for3Use2_13
+  val akkaHttpCore = ("com.typesafe.akka" %% "akka-http-core" % "10.2.6") cross CrossVersion.for3Use2_13
+  val akka = ("com.typesafe.akka" %% "akka-actor-typed" % "2.6.16") cross CrossVersion.for3Use2_13
 
   /**
    * jena
@@ -52,21 +52,21 @@ object Dependencies {
    * slf4j-nop. Test dependency for logging.
    * @see https://www.slf4j.org
    */
-  val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.7.21" % Test
+  val slf4jNop = "org.slf4j" % "slf4j-nop" % "1.7.32" % Test
 
   /**
    * Aalto
    * @see https://wiki.fasterxml.com/AaltoHome
    * @see https://repo1.maven.org/maven2/com/fasterxml/aalto-xml
    */
-  val aalto = "com.fasterxml" % "aalto-xml" % "1.0.0"
+  val aalto = "com.fasterxml" % "aalto-xml" % "1.3.0"
 
   /**
    * RDF4J
    * @see https://www.rdf4j.org/
    * @see https://repo1.maven.org/maven2/org/eclipse/rdf4j/
    */
-  val rdf4jVersion = "3.6.3"
+  val rdf4jVersion = "3.7.1"
 
   val rdf4jQueryAlgebra = "org.eclipse.rdf4j" % "rdf4j-queryalgebra-evaluation" % rdf4jVersion
   val rdf4jQueryParser = "org.eclipse.rdf4j" % "rdf4j-queryparser-sparql" % rdf4jVersion
@@ -83,7 +83,7 @@ object Dependencies {
    * @see https://github.com/jsonld-java/jsonld-java
    * @see https://repo.typesafe.com/typesafe/snapshots/com/github/jsonld-java/jsonld-java-tools
    */
-  val jsonldJava = "com.github.jsonld-java" % "jsonld-java" % "0.13.2"
+  val jsonldJava = "com.github.jsonld-java" % "jsonld-java" % "0.13.3"
 
   /**
    * parboiled

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.5.3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.5.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -41,7 +41,7 @@ addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.2")
   * @see http://www.scala-js.org/
   */
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.6.0")
 
 
 /**

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/SparqlGraphTest.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/SparqlGraphTest.scala
@@ -66,7 +66,7 @@ class SparqlGraphTest[Rdf <: RDF, SyntaxType](implicit
 
       val out = new ByteArrayOutputStream()
 
-      val serialisedAnswer = sparqlWriter.write(answers, out, "")
+      val serialisedAnswer = sparqlWriter.write(answers, out, None)
       assert(serialisedAnswer.isSuccess, "the sparql must be serialisable")
 
       val answr2 = sparqlReader.read(new ByteArrayInputStream(out.toByteArray), "")

--- a/rdf-test-suite/jvm/src/main/scala/org/w3/banana/io/NTriplesWriterTestSuite.scala
+++ b/rdf-test-suite/jvm/src/main/scala/org/w3/banana/io/NTriplesWriterTestSuite.scala
@@ -29,7 +29,7 @@ class NTriplesWriterTestSuite[Rdf <: RDF](implicit
     "write one triplet" in {
 
       val g = Graph(Triple(URI(bblfish), rdf.`type`, foaf.Person))
-      val str = writer.asString(g, base = "http://example").get
+      val str = writer.asString(g, base = Some("http://example")).get
       val graphTry = toGraph(ntparser(str))
       assert(graphTry.get isIsomorphicWith g)
     }
@@ -41,7 +41,7 @@ class NTriplesWriterTestSuite[Rdf <: RDF](implicit
         Triple(URI(bblfish), foaf.knows, BNode("betehess")),
         Triple(BNode("betehess"), foaf.homepage, URI("http://bertails.org/"))
       )
-      val str = writer.asString(g, base = "http://example").get
+      val str = writer.asString(g, base = Some("http://example")).get
       val graphTry = toGraph(ntparser(str))
       assert(graphTry.get isIsomorphicWith g)
     }

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/PrefixTestSuite.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/PrefixTestSuite.scala
@@ -1,8 +1,8 @@
 package org.w3.banana.io
 
 import org.w3.banana.{Prefix, RDF, RDFOps}
-
-import scalaz._, scalaz.syntax.comonad._
+import scalaz._
+import scalaz.syntax.comonad._
 
 abstract class PrefixTestSuite[Rdf <: RDF, M[+ _] : Monad : Comonad](implicit
   ops: RDFOps[Rdf],
@@ -26,14 +26,15 @@ abstract class PrefixTestSuite[Rdf <: RDF, M[+ _] : Monad : Comonad](implicit
     //        |        foo:creator    "Dave Beckett" , "Art Barstow" ;
     //        |        foo:publisher  <http://www.w3.org/> .""".stripMargin
 
-    val withPrefix = writer.asString(referenceGraph, "", prefix).copoint
+    val withPrefix = writer.asString(referenceGraph, None, prefix).copoint
     withPrefix should include("@prefix foo:")
     withPrefix should include("foo:creator")
     withPrefix should include("foo:publisher")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/creator>")
     withPrefix should not include ("<http://purl.org/dc/elements/1.1/publisher>")
 
-    val noPrefix = writer.asString(referenceGraph, "").copoint
+    val noPrefix = writer.asString(referenceGraph, None).copoint
+    println(s"noPrefix=$noPrefix")
     noPrefix should not include ("@prefix foo:")
     noPrefix should not include ("foo:creator")
     noPrefix should not include ("foo:publisher")

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/RelativeGraphSerialisationTestSuite.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/RelativeGraphSerialisationTestSuite.scala
@@ -1,0 +1,123 @@
+package org.w3.banana.io
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.w3.banana.{PointedGraph, PointedGraphTest, RDF, RDFOps, WebACLPrefix}
+
+import scalaz._
+import scalaz.syntax._
+import comonad._
+import monad._
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, StringReader}
+
+
+/**
+ * Not all formats allow serialisation of graphs with Relative URLs, so here
+ * we place tests designed to stress test the implementations of those syntaxes.
+ *
+ * Relative RDF graphs are essential when POST-ing
+ *
+ * @param syntax e.g. "Turtle", ...
+ * @param extension e.g. "ttl"
+ * @param ops
+ * @param reader
+ * @param writer
+ * @tparam Rdf
+ * @tparam M is a Monad like Euther or Future, and not a Comonad. That just allows a uniform access to `get`
+ *           and so is a terrible hack.
+ * @tparam Sin Type for input Syntax
+ * @tparam Sout Type of output Syntax
+ */
+abstract class RelativeGraphSerialisationTestSuite[Rdf <: RDF, M[+_]: Monad : Comonad, Sin, Sout](
+  syntax: String,
+  extension: String
+)(implicit
+  ops: RDFOps[Rdf],
+  reader: RDFReader[Rdf, M, Sin],
+  writer: RDFWriter[Rdf, M, Sout]
+) extends AnyWordSpec with Matchers {
+
+  import org.w3.banana._
+
+  def gr(pg: PointedGraph[Rdf]): Rdf#Graph = pg.graph
+
+  import ops._
+
+  val wac = WebACLPrefix[Rdf]
+  val foaf = FOAFPrefix[Rdf]
+
+  val w3c : Rdf#URI = URI("https://www.w3.org/")
+  val timBlcardURI = URI("https://www.w3.org/People/Berners-Lee/card")
+
+  /**
+   * we use a realistic example from access control shown in the diagram given in
+   *[[https://github.com/solid/authorization-panel/issues/210 issue 210]] of Solid Authorization panel.
+   * `rootACL` is meant to be PUT to `</.acl>` of W3C Web server.
+   */
+  val rootACL = gr(URI("/.acl#Admin").a(wac.Authorization)
+    -- wac.mode ->- wac.Control
+    -- wac.agent ->- URI("/owner#i")
+    -- wac.default ->- URI("/")
+  ) union gr(
+    URI("/.acl#Public").a(wac.Authorization)
+      -- wac.default ->- URI("/")
+      -- wac.mode ->- wac.Read
+      -- wac.agentClass ->- foaf.Agent
+  )
+
+  /**
+   * This is the document that is to be POSTed with `Slug: card` onto
+   * the container `</People/Berners-Lee/>` creating Tim's WebID. */
+  val BLcard = gr(
+    URI("#i").a(foaf.Person)
+      -- foaf.name ->- "Tim Berners-Lee"
+      -- foaf.workInfoHomepage ->- URI("/")
+  )
+
+  val timbl = timBlcardURI.withFragment("i")
+  val BLcardAbsolute = Graph(
+    Triple(timbl, rdf.`type`, foaf.Person),
+    Triple(timbl,foaf.name,Literal("Tim Berners-Lee")),
+    Triple(timbl,foaf.workInfoHomepage,w3c)
+  )
+
+  /**
+   * This is the ACL that is meant to be PUT on `</People/Berners-Lee/.acl>`
+   */
+  val BLAcl   = gr( URI("#TimRl").a(wac.Authorization)
+    -- wac.agent ->- URI("card#i")
+    -- wac.mode ->- wac.Control
+    -- wac.default ->-  URI(".")
+  ) union gr(
+    URI("") -- owl.imports ->- URI("/.acl")
+  )
+
+  s"writing relative graphs to $syntax and reading them back from correct base" should {
+
+    "result in isomorphic graphs root container acl" in {
+      //1. we build a serialisation with relative URLs
+      val rootACLStr: String = writer.asString(rootACL,None).copoint
+      //2. after PUTing it to the acl location, we fetch it and parse it with the relative URL location.
+      val reconstructedGraph = reader.read(new StringReader(rootACLStr), "https://www.w3.org/.acl").copoint
+      val absoluteRootACLGr = rootACL.resolveAgainst(w3c)
+      //3. we compare the result with the absolutized graph we should have received
+      assert(reconstructedGraph isIsomorphicWith absoluteRootACLGr,
+        s"both graphs be isomorphic:\nresult=$reconstructedGraph\nshouldBe=$absoluteRootACLGr")
+
+    }
+
+    "result in isomorphic graph for TimBL's card" in {
+      //1. we build a serialisation with relative URLs
+      val BLCardStr: String = writer.asString(BLcard,None).copoint
+      //2. we POST it to Tim's Personal W3C Container with a Slug "card",
+      //   then GET it the newly constructed resource and parse it with the new base,
+      val reconstructedGraph = reader.read(new StringReader(BLCardStr), timBlcardURI.toString).copoint
+      //3. we compare the result with the absolutized graph we should have received
+      assert(reconstructedGraph isIsomorphicWith BLcardAbsolute,
+        s"both graphs be isomorphic:\nresult=$reconstructedGraph\nshouldBe=$BLcardAbsolute")
+    }
+
+  }
+
+}

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/RelativeGraphSerialisationTestSuite.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/RelativeGraphSerialisationTestSuite.scala
@@ -78,8 +78,8 @@ abstract class RelativeGraphSerialisationTestSuite[Rdf <: RDF, M[+_]: Monad : Co
   val timbl = timBlcardURI.withFragment("i")
   val BLcardAbsolute = Graph(
     Triple(timbl, rdf.`type`, foaf.Person),
-    Triple(timbl,foaf.name,Literal("Tim Berners-Lee")),
-    Triple(timbl,foaf.workInfoHomepage,w3c)
+    Triple(timbl, foaf.name, Literal("Tim Berners-Lee")),
+    Triple(timbl, foaf.workInfoHomepage, w3c)
   )
 
   /**
@@ -92,6 +92,18 @@ abstract class RelativeGraphSerialisationTestSuite[Rdf <: RDF, M[+_]: Monad : Co
   ) union gr(
     URI("") -- owl.imports ->- URI("/.acl")
   )
+  s"Writing the empty graph in $syntax" should {
+    "not throw an exception" in {
+      writer.asString(Graph.empty,None).copoint
+    }
+  }
+  
+  s"Writing self references" should {
+    val defaultACLGraph: Rdf#Graph = (URI("") -- owl.imports ->- URI(".acl")).graph
+    "not throw an exception" in {
+      writer.asString(defaultACLGraph,None).copoint
+    }
+  }
 
   s"writing relative graphs to $syntax and reading them back from correct base" should {
 

--- a/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/RelativeTurtleTestSuite.scala
+++ b/rdf-test-suite/shared/src/main/scala/org/w3/banana/io/RelativeTurtleTestSuite.scala
@@ -1,0 +1,12 @@
+package org.w3.banana.io
+
+import org.w3.banana.{RDF, RDFOps}
+import scalaz.{Comonad, Monad}
+
+abstract class RelativeTurtleTestSuite[Rdf <: RDF, M[+_] : Monad : Comonad](implicit
+  ops: RDFOps[Rdf],
+  reader: RDFReader[Rdf, M, Turtle],
+  val writer: RDFWriter[Rdf, M, Turtle]
+) extends RelativeGraphSerialisationTestSuite[Rdf, M, Turtle, Turtle]("Turtle", "ttl") {
+  
+}

--- a/rdf/shared/src/main/scala/org/w3/banana/PointedGraphs.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/PointedGraphs.scala
@@ -11,12 +11,18 @@ class PointedGraphs[Rdf <: RDF](val nodes: Iterable[Rdf#Node], val graph: Rdf#Gr
     nodes.mkString("[", " ; ", "]")
   }
 
-  def iterator = nodes.iterator map { PointedGraph(_, graph) }
+  def iterator: Iterator[PointedGraph[Rdf]] = nodes.iterator map { PointedGraph(_, graph) }
 
   def /(p: Rdf#URI)(implicit ops: RDFOps[Rdf]): PointedGraphs[Rdf] = {
-    val ns: Iterable[Rdf#Node] = this flatMap { (pointed: PointedGraph[Rdf]) =>
-      import pointed.pointer
-      ops.getObjects(graph, pointer, p)
+    val ns: Iterable[Rdf#Node] = nodes flatMap { node =>
+      ops.getObjects(graph, node, p)
+    }
+    new PointedGraphs[Rdf](ns, graph)
+  }
+
+  def /-(p: Rdf#URI)(implicit ops: RDFOps[Rdf]): PointedGraphs[Rdf] = {
+    val ns: Iterable[Rdf#Node] = nodes flatMap { node =>
+      ops.getSubjects(graph, p, node)
     }
     new PointedGraphs[Rdf](ns, graph)
   }

--- a/rdf/shared/src/main/scala/org/w3/banana/Prefix.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/Prefix.scala
@@ -385,25 +385,29 @@ object WebACLPrefix {
 }
 
 class WebACLPrefix[Rdf <: RDF](ops: RDFOps[Rdf]) extends PrefixBuilder("acl", "http://www.w3.org/ns/auth/acl#")(ops) {
-  val Authorization = apply("Authorization")
-  val agent = apply("agent")
-  val agentClass = apply("agentClass")
-  val accessTo = apply("accessTo")
-  val accessToClass = apply("accessToClass")
-  val defaultForNew = apply("defaultForNew")
-  val mode = apply("mode")
   val Access = apply("Access")
+  val Append = apply("Append")
+  val AuthenticatedAgent = apply("AuthenticatedAgent")
+  val Authorization = apply("Authorization")
+  val Control = apply("Control")
+  val Origin = apply("Origin")
   val Read = apply("Read")
   val Write = apply("Write")
-  val Append = apply("Append")
   val accessControl = apply("accessControl")
-  val Control = apply("Control")
+  val accessTo = apply("accessTo")
+  val accessToClass = apply("accessToClass")
+  val agent = apply("agent")
+  val agentClass = apply("agentClass")
+  val agentGroup = apply("agentGroup")
+  val default = apply("default")
+  val defaultForNew = apply("defaultForNew")
+  val delegates = apply("delegates")
+  val mode = apply("mode")
+  val origin = apply("origin")
   val owner = apply("owner")
-  val WebIDAgent = apply("WebIDAgent")
 
   //not officially supported:
-  val include = apply("include")
-  val regex = apply("regex")
+  val imports = apply("imports")
 }
 
 object CertPrefix {

--- a/rdf/shared/src/main/scala/org/w3/banana/io/BooleanWriter.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/BooleanWriter.scala
@@ -9,7 +9,7 @@ trait BooleanWriter[T] extends Writer[Boolean, Try, T] {
 
   def format(bool: Boolean): String
 
-  def asString(bool: Boolean, base: String): Try[String] = Try {
+  def asString(bool: Boolean, base: Option[String]): Try[String] = Try {
     format(bool)
   }
 
@@ -29,7 +29,7 @@ object BooleanWriter {
         |}
         | """.stripMargin.format(bool)
 
-    override def write(obj: Boolean, outputstream: OutputStream, base: String) : Try[Unit] = ???
+    override def write(obj: Boolean, outputstream: OutputStream, base: Option[String]) : Try[Unit] = ???
 
   }
 
@@ -45,7 +45,7 @@ object BooleanWriter {
         |  <boolean>%s</boolean>
         |</sparql> """.stripMargin.format(bool) // "
 
-    override def write(obj: Boolean, outputstream: OutputStream, base: String): Try[Unit] = ???
+    override def write(obj: Boolean, outputstream: OutputStream, base: Option[String]): Try[Unit] = ???
   }
 
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/RDFWriter.scala
@@ -5,12 +5,12 @@ import java.io.OutputStream
 
 trait RDFWriter[Rdf <: RDF, M[_], +T] extends Writer[Rdf#Graph,M,T] {
 
-  override def write(obj: Rdf#Graph, os: OutputStream, base: String): M[Unit] = write(obj, os, base, Set())
+  override def write(obj: Rdf#Graph, os: OutputStream, base: Option[String]): M[Unit] = write(obj, os, base, Set())
 
-  def write(graph: Rdf#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Rdf]]): M[Unit]
+  def write(graph: Rdf#Graph, os: OutputStream, base: Option[String], prefixes: Set[Prefix[Rdf]]): M[Unit]
 
-  override def asString(obj: Rdf#Graph, base: String): M[String] = asString(obj, base, Set())
+  override def asString(obj: Rdf#Graph, base: Option[String]): M[String] = asString(obj, base, Set())
 
-  def asString(graph: Rdf#Graph, base: String, prefixes: Set[Prefix[Rdf]]): M[String]
+  def asString(graph: Rdf#Graph, base: Option[String], prefixes: Set[Prefix[Rdf]]): M[String]
 
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/io/Writer.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/io/Writer.scala
@@ -11,8 +11,13 @@ trait Writer[-O, M[_], +T] {
 
   //todo: add a method that takes a writer
 
-  //todo: this method needs an encoding
-  def write(obj: O, outputstream: OutputStream, base: String): M[Unit]
+  /**
+   * todo: this method is missing an encoding
+   * @param obj the object to serialise
+   * @param outputstream the output stream to serialise to
+   * @param base the optional base of the document, so that URLs are relativised to that base. This essentially takes a graph with absolute URLs and turns it into a relative graph before serialising it. Not needed if the graph is already relative, hence the use of Option.
+   **/
+  def write(obj: O, outputstream: OutputStream, base: Option[String]): M[Unit]
 
-  def asString(obj: O, base: String): M[String]
+  def asString(obj: O, base: Option[String]): M[String]
 }

--- a/rdf/shared/src/main/scala/org/w3/banana/syntax/GraphSyntax.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/syntax/GraphSyntax.scala
@@ -21,9 +21,16 @@ class GraphW[Rdf <: RDF](val graph: Rdf#Graph) extends AnyVal {
   def isIsomorphicWith(otherGraph: Rdf#Graph)(implicit ops: RDFOps[Rdf]): Boolean = ops.isomorphism(graph, otherGraph)
 
   def contains(triple: Rdf#Triple)(implicit ops: RDFOps[Rdf]): Boolean = {
-    val (sub, rel, obj) = ops.fromTriple(triple)
     import ops.toConcreteNodeMatch
-    ops.find(graph, sub, rel, obj).hasNext
+    val (sub, rel, obj) = ops.fromTriple(triple)
+    select(sub,rel,obj).hasNext
+  }
+
+  /* note: this method could also be called find, but it clashes with jena's underlying
+   * graph.find. A bit awkward. Moving to Scala3 opaque types might help.
+   **/
+  def select(sub: Rdf#NodeMatch, rel: Rdf#NodeMatch, obj: Rdf#NodeMatch)(implicit ops: RDFOps[Rdf]): Iterator[Rdf#Triple] = {
+    ops.find(graph, sub, rel, obj)
   }
 
   /**

--- a/rdf/shared/src/main/scala/org/w3/banana/util/TryInstances.scala
+++ b/rdf/shared/src/main/scala/org/w3/banana/util/TryInstances.scala
@@ -4,6 +4,7 @@ package util
 import scalaz.{ Monad, Comonad }
 import scala.util.Try
 
+//todo: these should only be in the test suite, if there
 object tryInstances {
   implicit final val TryInstance: Monad[Try] with Comonad[Try] = new Monad[Try] with Comonad[Try] {
     def point[A](a: => A): Try[A] = Try[A](a)

--- a/rdf4j/src/main/scala/org/w3/banana/rdf4j/io/Rdf4jRDFWriter.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rdf4j/io/Rdf4jRDFWriter.scala
@@ -13,7 +13,7 @@ class Rdf4jRDFWriter[T](implicit
                         rdf4jSyntax: Rdf4jSyntax[T]
 ) extends RDFWriter[Rdf4j, Try, T] {
 
-  def write(graph: Rdf4j#Graph, os: OutputStream, base: String, prefixes: Set[Prefix[Rdf4j]]): Try[Unit] = Try {
+  def write(graph: Rdf4j#Graph, os: OutputStream, base: Option[String], prefixes: Set[Prefix[Rdf4j]]): Try[Unit] = Try {
     val sWriter = rdf4jSyntax.rdfWriter(os, base)
     sWriter.startRDF()
     prefixes.foreach(p => {
@@ -23,7 +23,7 @@ class Rdf4jRDFWriter[T](implicit
     sWriter.endRDF()
   }
 
-  def asString(graph: Rdf4j#Graph, base: String, prefixes: Set[Prefix[Rdf4j]]): Try[String] = Try {
+  def asString(graph: Rdf4j#Graph, base: Option[String], prefixes: Set[Prefix[Rdf4j]]): Try[String] = Try {
     val result = new StringWriter()
     val sWriter = rdf4jSyntax.rdfWriter(result, base)
     sWriter.startRDF()

--- a/rdf4j/src/main/scala/org/w3/banana/rdf4j/io/Rdf4jSolutionsWriter.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rdf4j/io/Rdf4jSolutionsWriter.scala
@@ -13,7 +13,7 @@ private abstract class Rdf4jSolutionsWriter[S] extends SparqlSolutionsWriter[Rdf
 
   def writer(outputStream: OutputStream): TupleQueryResultWriter
 
-  def write(answers: Rdf4j#Solutions, os: OutputStream, base: String) = Try {
+  def write(answers: Rdf4j#Solutions, os: OutputStream, base: Option[String]) = Try {
     val sWriter = writer(os)
     // sWriter.startQueryResult(answers.getBindingNames)
     sWriter.startQueryResult(new java.util.ArrayList()) // <- yeah, probably wrong...
@@ -21,7 +21,7 @@ private abstract class Rdf4jSolutionsWriter[S] extends SparqlSolutionsWriter[Rdf
     sWriter.endQueryResult()
   }
 
-  def asString(answers: Rdf4j#Solutions, base: String) = Try {
+  def asString(answers: Rdf4j#Solutions, base: Option[String]) = Try {
     // TODO this goes through the lossy outputstream in order to then
     // recode a string, even though it does not really know what the
     // required encoding is

--- a/rdf4j/src/main/scala/org/w3/banana/rdf4j/io/Rdf4jSyntax.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rdf4j/io/Rdf4jSyntax.scala
@@ -1,57 +1,74 @@
 package org.w3.banana.rdf4j.io
 
-import java.io.{OutputStream, Writer}
-import java.net.{URI => jURI}
-
 import org.eclipse.rdf4j.model.{Statement, IRI => rdf4jIRI}
-import org.eclipse.rdf4j.rio.RDFWriter
 import org.eclipse.rdf4j.rio.helpers.{JSONLDMode, JSONLDSettings}
 import org.eclipse.rdf4j.rio.jsonld.JSONLDWriter
 import org.eclipse.rdf4j.rio.rdfxml.{RDFXMLWriter => SRdfXmlWriter}
 import org.eclipse.rdf4j.rio.turtle.{TurtleWriter => STurtleWriter}
+import org.eclipse.rdf4j.rio.{RDFWriter => RioRDFWriter}
 import org.w3.banana.io._
+
+import java.io.{OutputStream, Writer}
+import java.net.{URI => jURI}
 
 /** Typeclass that reflects an RDF4J String that can be used to construct an RDFWriter. */
 trait Rdf4jSyntax[T] {
-  def rdfWriter(os: OutputStream, base: String): RDFWriter
-  def rdfWriter(wr: Writer, base: String): RDFWriter
+  def rdfWriter(os: OutputStream, base: Option[String]): RioRDFWriter
+  def rdfWriter(wr: Writer, base: Option[String]): RioRDFWriter
 }
 
 object Rdf4jSyntax {
 
   implicit val RDFXML: Rdf4jSyntax[RDFXML] = new Rdf4jSyntax[RDFXML] {
+
     import org.w3.banana.rdf4j.Rdf4j.ops._
+
     // RDF4J's parser does not handle relative URI, but let us override the behavior :-)
-    def rdfWriter(os: OutputStream, base: String) = new SRdfXmlWriter(os) {
-      val baseUri = URI(base)
-      override def handleStatement(st: Statement) = {
-        super.handleStatement(st.relativizeAgainst(baseUri))
+    def rdfWriter(os: OutputStream, base: Option[String]) = base match {
+      case None => new SRdfXmlWriter(os)
+      case Some(baseStr) => new SRdfXmlWriter(os) {
+        val baseUri = URI(baseStr)
+
+        override def handleStatement(st: Statement) = {
+          super.handleStatement(st.relativizeAgainst(baseUri))
+        }
       }
     }
 
-    def rdfWriter(wr: Writer, base: String) = new SRdfXmlWriter(wr) {
-      val baseUri = URI(base)
-      override def handleStatement(st: Statement) = {
-        super.handleStatement(st.relativizeAgainst(baseUri))
+
+    def rdfWriter(wr: Writer, base: Option[String]) = base match {
+      case None => new SRdfXmlWriter(wr)
+      case Some(baseStr) => new SRdfXmlWriter(wr) {
+        val baseUri = URI(baseStr)
+
+        override def handleStatement(st: Statement) = {
+          super.handleStatement(st.relativizeAgainst(baseUri))
+        }
       }
     }
   }
 
   implicit val Turtle: Rdf4jSyntax[Turtle] = new Rdf4jSyntax[Turtle] {
+
     import org.w3.banana.rdf4j.Rdf4j.ops._
+
     // RDF4J's parser does not handle relative URI, but let us override the behavior :-)
-    def relativize(uri: rdf4jIRI, baseURI: jURI): Either[rdf4jIRI, String] = {
-      val juri = new jURI(uri.toString)
-      val relative = baseURI.relativize(juri).toString
+    def relativize(uri: rdf4jIRI, baseURI: Option[jURI]): Either[rdf4jIRI, String] =
+      baseURI match {
+        case None => Left(uri)
+        case Some(base) => {
+          val juri     = new jURI(uri.toString)
+          val relative = base.relativize(juri).toString
 
-      if (relative.length > 0) Left(makeUri(relative)) else Right(relative)
-    }
+          if (relative.length > 0) Left(makeUri(relative)) else Right(relative)
+        }
+      }
 
-    def rdfWriter(os: OutputStream, base: String) = new STurtleWriter(os) {
-      val baseUri = new jURI(base)
+    def rdfWriter(os: OutputStream, base: Option[String]) = new STurtleWriter(os) {
+      val baseUriOpt = base.map(bs => new jURI(bs))
 
       override def writeURI(uri: rdf4jIRI): Unit = {
-        val uriToWrite = relativize(uri, baseUri)
+        val uriToWrite: Either[rdf4jIRI, String] = relativize(uri, baseUriOpt)
         uriToWrite.fold(
           super.writeURI,
           s => writer.write("<" + s + ">")
@@ -59,11 +76,11 @@ object Rdf4jSyntax {
       }
     }
 
-    def rdfWriter(wr: Writer, base: String) = new STurtleWriter(wr) {
-      val baseUri = new jURI(base)
+    def rdfWriter(wr: Writer, base: Option[String]) = new STurtleWriter(wr) {
+      val baseUriOpt = base.map(bs => new jURI(bs))
 
       override def writeURI(uri: rdf4jIRI): Unit = {
-        val uriToWrite = relativize(uri, baseUri)
+        val uriToWrite = relativize(uri, baseUriOpt)
         uriToWrite.fold(
           super.writeURI,
           s => writer.write("<" + s + ">")
@@ -81,21 +98,28 @@ object Rdf4jSyntax {
   private def jsonldSyntax[T](mode: JSONLDMode) = new Rdf4jSyntax[T] {
     import org.w3.banana.rdf4j.Rdf4j.ops._
 
-    def rdfWriter(os: OutputStream, base: String) = {
-      val baseUri = URI(base)
-      val writer = new JSONLDWriter(os) {
-        override def handleStatement(st: Statement) = {
-          super.handleStatement(st.relativizeAgainst(baseUri))
+    def rdfWriter(os: OutputStream, base: Option[String]): JSONLDWriter = {
+      val baseUri = base.map(bs => URI(bs))
+      val writer  = baseUri match {
+        case None => new JSONLDWriter(os)
+        case Some(baseURI) => new JSONLDWriter(os) {
+          override def handleStatement(st: Statement) = {
+            super.handleStatement(st.relativizeAgainst(baseURI))
+          }
         }
       }
       writer.getWriterConfig().set(JSONLDSettings.JSONLD_MODE, mode);
       writer
     }
-    def rdfWriter(wr: Writer, base: String) = {
-      val baseUri = URI(base)
-      val writer = new JSONLDWriter(wr)  {
-        override def handleStatement(st: Statement) = {
-          super.handleStatement(st.relativizeAgainst(baseUri))
+
+    def rdfWriter(wr: Writer, base: Option[String]): JSONLDWriter = {
+      val baseUri = base.map(bs => URI(bs))
+      val writer  = baseUri match {
+        case None => new JSONLDWriter(wr)
+        case Some(baseURI) => new JSONLDWriter(wr) {
+          override def handleStatement(st: Statement) = {
+            super.handleStatement(st.relativizeAgainst(baseURI))
+          }
         }
       }
       writer.getWriterConfig().set(JSONLDSettings.JSONLD_MODE, mode);

--- a/rdf4j/src/main/scala/org/w3/banana/rdf4j/io/Rdf4jSyntax.scala
+++ b/rdf4j/src/main/scala/org/w3/banana/rdf4j/io/Rdf4jSyntax.scala
@@ -55,12 +55,12 @@ object Rdf4jSyntax {
     // RDF4J's parser does not handle relative URI, but let us override the behavior :-)
     def relativize(uri: rdf4jIRI, baseURI: Option[jURI]): Either[rdf4jIRI, String] =
       baseURI match {
-        case None => Left(uri)
+        case None => if (uri.toString.length > 0) Left(uri) else Right("")
         case Some(base) => {
           val juri     = new jURI(uri.toString)
           val relative = base.relativize(juri).toString
 
-          if (relative.length > 0) Left(makeUri(relative)) else Right(relative)
+          if (relative.length > 0) Left(makeUri(relative)) else Right("")
         }
       }
 

--- a/rdf4j/src/test/scala/org/w3/banana/rdf4j/io/Rdf4jSerialisationTests.scala
+++ b/rdf4j/src/test/scala/org/w3/banana/rdf4j/io/Rdf4jSerialisationTests.scala
@@ -8,6 +8,8 @@ import scala.util.Try
 
 class Rdf4jTurtleTests extends TurtleTestSuite[Rdf4j, Try]
 
+class Rdf4jRelativeTurtleTest extends RelativeTurtleTestSuite[Rdf4j, Try]
+
 class Rdf4jPrefixTest extends PrefixTestSuite[Rdf4j, Try]
 
 class Rdf4jNTripleReaderTestSuite extends NTriplesReaderTestSuite[Rdf4j]


### PR DESCRIPTION
This is a change that could have some effect on code using banana-rdf.
I often have relative graphs that I need to serialise and I don't want a pass to set the base. It was not clear what "" as base would do, but it does not do the right thing.
If we could have a relative RDF graph type, then we could remove the need for a base altogether.